### PR TITLE
Added functioning ClassicController support, including changes to test app for verifcation.

### DIFF
--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -242,6 +242,9 @@ namespace dolphiimote {
   void capability_discoverer::enable_motion_plus_extension_passthrough(int wiimote_number)
   {
     sender.write_register(wiimote_number, 0xA600FE, 0x05, 1);
+    
+    /* for Classic Controller Interleave with MotionPlus, need to send 0x07, not 0x05 (numchuck)
+    sender.write_register(wiimote_number, 0xA600FE, 0x07, 1);*/
 
     auto& mote = wiimote_states[wiimote_number];
 

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -44,6 +44,16 @@ namespace dolphiimote {
       return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::Nunchuck)(mote) && motion_plus_filter()(mote); };
     }
 
+    std::function<bool(const wiimote&)> classic_controller_filter()
+    {
+      return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::ClassicController)(mote) && !motion_plus_filter()(mote); };
+    }
+
+    std::function<bool(const wiimote&)> interleaved_classic_controller_filter()
+    {
+      return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::ClassicController)(mote) && motion_plus_filter()(mote); };
+    }
+
     void setup_retrievers()
     {
       standard_retrievers.push_back(std::make_pair(0xFFFF, serialization::retrieve_button_state));
@@ -53,6 +63,8 @@ namespace dolphiimote {
       extension_retrievers.push_back(std::make_pair(motion_plus_filter(), serialization::retrieve_motion_plus));
       extension_retrievers.push_back(std::make_pair(nunchuck_filter(), serialization::retrieve_nunchuck));
       extension_retrievers.push_back(std::make_pair(interleaved_nunchuck_filter(), serialization::retrieve_interleaved_nunchuck));
+      extension_retrievers.push_back(std::make_pair(classic_controller_filter(), serialization::retrieve_classic_controller));
+      extension_retrievers.push_back(std::make_pair(interleaved_classic_controller_filter(), serialization::retrieve_interleaved_classic_controller));
     }
 
     void setup_extension_offsets()

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -60,6 +60,24 @@ typedef struct dolphiimote_nunchuck
 
 } dolphiimote_nunchuck;
 
+typedef struct dolphiimote_classic_controller
+{
+  //left analog stick, 0-63
+  uint8_t left_stick_x;
+  uint8_t left_stick_y;
+
+  //right analog stick, 0-31
+  uint8_t right_stick_x;
+  uint8_t right_stick_y;
+
+  //analog triggers, 0-31
+  uint8_t left_trigger;
+  uint8_t right_trigger;
+
+  uint16_t buttons;
+
+} dolphiimote_classic_controller;
+
 typedef struct dolphiimote_motionplus
 {
   uint16_t yaw_down_speed;
@@ -79,6 +97,7 @@ typedef struct dolphiimote_wiimote_data
   dolphiimote_acceleration acceleration;
   dolphiimote_motionplus motionplus;
   dolphiimote_nunchuck nunchuck;
+  dolphiimote_classic_controller classic_controller;
 } dolphiimote_wiimote_data;
 
 typedef struct dolphiimote_capability_status
@@ -173,6 +192,7 @@ void dolphiimote_log_level(uint8_t log_level);
 #define dolphiimote_ACCELERATION_VALID 0x0002
 #define dolphiimote_MOTIONPLUS_VALID 0x0004
 #define dolphiimote_NUNCHUCK_VALID 0x0008
+#define dolphiimote_CLASSIC_CONTROLLER_VALID 0x0001
 
 /*
   These are the button states, as they are saved in dolphiimote_button_state
@@ -200,6 +220,30 @@ void dolphiimote_log_level(uint8_t log_level);
 */
 #define dolphiimote_NUNCHUCK_BUTTON_Z 0x01
 #define dolphiimote_NUNCHUCK_BUTTON_C 0x02
+
+/*
+  dolphiimote_CLASSIC_CONTROLLER_BUTTON_* are the Classic Controller buttons, as they are saved in dolphiimote_classic_controller
+*/
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_LEFT 0x0002
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_RIGHT 0x8000
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_DOWN 0x4000
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_UP 0x0001
+
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_A 0x0010
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_B 0x0040
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_X 0x0008
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_Y 0x0020
+
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_LEFT 0x2000
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_RIGHT 0x0200
+
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_LEFT 0x0080
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_RIGHT 0x0004
+
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_PLUS 0x0400
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_MINUS 0x1000
+
+#define dolphiimote_CLASSIC_CONTROLLER_BUTTON_HOME 0x0800
 
 /*
   dolphiimote_EXTENSION_* are the available extension types. Use them with dolphiimote_capability_status.extension_type

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -85,6 +85,47 @@ namespace dolphiimote { namespace serialization {
     }
   }
 
+  void retrieve_classic_controller(checked_array<const u8> extension_data, dolphiimote_wiimote_data &output)
+  {
+	  if(extension_data.size() >= 6)
+    { 	  
+      output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
+
+      output.classic_controller.left_stick_x = extension_data[0] & 0x3F;
+      output.classic_controller.left_stick_y = extension_data[1] & 0x3F;
+
+      output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
+      output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
+
+      output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
+      output.classic_controller.right_trigger = extension_data[3] & 0x1F;
+
+      output.classic_controller.buttons = ~((extension_data[4] << 8) | extension_data[5]);
+    }
+  }
+
+  void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, dolphiimote_wiimote_data &output)
+  {
+	  if(extension_data.size() >= 6)
+    {
+      if((extension_data[5] & 0x03) == 0)
+      {
+        output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
+
+        output.classic_controller.left_stick_x = extension_data[0] & 0x3E;
+        output.classic_controller.left_stick_y = extension_data[1] & 0x3E;
+
+        output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
+        output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
+
+        output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
+        output.classic_controller.right_trigger = extension_data[3] & 0x1F;
+
+        output.classic_controller.buttons = ~(((extension_data[4] & 0xFE ) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
+      }
+    }
+  }
+
   void retrieve_button_state(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output)
   {
     if(data.size() > 4)

--- a/DolphiiMote/Core/serialization.h
+++ b/DolphiiMote/Core/serialization.h
@@ -33,6 +33,8 @@ namespace dolphiimote { namespace serialization {
   void retrieve_button_state(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output);
   void retrieve_infrared_camera_data(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output);
   void retrieve_acceleration_data(u8 reporting_mode, checked_array<const u8> data, struct dolphiimote_wiimote_data &output);
+  void retrieve_classic_controller(checked_array<const u8> extension_data, dolphiimote_wiimote_data &output);
+  void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, dolphiimote_wiimote_data &output);
   }
 }
 

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -23,7 +23,7 @@ int state = 0;
 
 void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *data, void *userdata)
 {
-  printf("wiimote %i:\t", wiimote_number);
+  printf("wiimote %i: ", wiimote_number);
 
   if(data->button_state & dolphiimote_BUTTON_A)
   {
@@ -78,6 +78,55 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
     int c = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_C;
     int z = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_Z;
     printf("Nunchuck: C: %i, Z: %i, Acc: %02X%02X%02X Stick X: %i, Y: %i\t", c, z, data->nunchuck.x, data->nunchuck.y, data->nunchuck.z, data->nunchuck.stick_x, data->nunchuck.stick_y);
+  }
+
+  if(data->valid_data_flags & dolphiimote_CLASSIC_CONTROLLER_VALID)
+  {
+
+    int lx = data->classic_controller.left_stick_x;
+    int ly = data->classic_controller.left_stick_y;
+    int rx = data->classic_controller.right_stick_x;
+    int ry = data->classic_controller.right_stick_y;
+    int lt = data->classic_controller.left_trigger;
+    int rt = data->classic_controller.right_trigger;
+
+    printf("Classic: L:%02d,%02d R:%02d,%02d T:%02d,%02d\t",lx,ly,rx,ry,lt,rt);
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_A)
+      printf("A");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_B)
+      printf("B");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_X)
+      printf("X");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Y)
+      printf("Y");
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_LEFT)
+      printf("DL");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_RIGHT)
+      printf("DR");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_DOWN)
+      printf("DD");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_UP)
+      printf("DU");
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_LEFT)
+      printf("LT");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_RIGHT)
+      printf("RT");
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_LEFT)
+      printf("LZ");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_RIGHT)
+      printf("RZ");
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_PLUS)
+      printf("+");
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_MINUS)
+      printf("-");
+
+    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_HOME)
+      printf("H");
   }
 
   printf("\n");


### PR DESCRIPTION
I searched around online a bit and found that no one took your brother up on the offer to implement ClassicController support for FreePIE, so I went ahead and got it working with a little help from wiibrew.org's reverse-engineered protocol information.

I modified the test application to include testing support for the ClassicController, and it all seems to work well.

I also added support for interleaving ClassicController/MotionPlus data, but there are various problems getting it to work, one of which is indicated in a comment block in capability_discoverer.cpp.

I'm hoping these changes can make their way up to FreePIE so the ClassicController can be supported in the near future.  Thanks!
