### PR TITLE
Add Motion Plus interleaving support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp/**
 *.sdf
 *.filters
 *.opensdf
+*.opendb
+*.VC.db

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -15,7 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with DolphiiMote.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "capability_discoverer.h"
+#include "capability_discoverer.h"#include <chrono>
+#include <thread>
 
 namespace dolphiimote {
 
@@ -133,8 +134,10 @@ namespace dolphiimote {
 
 		fill_capabilities(status, wiimote_states[wiimote]);
 
-		if (callbacks.capabilities_changed)
+		if (callbacks.capabilities_changed) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 			callbacks.capabilities_changed(wiimote, &status, callbacks.userdata);
+		}
 	}
 
 	std::map<u64, wiimote_extensions::type> _id_to_extension_type;

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -228,6 +228,9 @@ namespace dolphiimote {
 			reader.read(wiimote_number, 0xA40024, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 			reader.read(wiimote_number, 0xA40024 + 16, 8, std::bind(&capability_discoverer::handle_balanceboard_calibration2, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 		}
+		if (mote.extension_type == wiimote_extensions::Passthrough && mote.extension_id == 0) {
+			mote.extension_type = wiimote_extensions::Unknown;
+		}
 		//Appearently calibration data is stored for joysticks and things, but this is probably a pointless thing to bother calibrating for.
 		/*if (mote.extension_type == wiimote_extensions::Nunchuck) {
 			reader.read(wiimote_number, 0xA40020, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -37,6 +37,9 @@ namespace dolphiimote {
 				if (!is_set(mote.available_capabilities, wiimote_capabilities::Extension)) {
 					//Even if we arent using passthrough mode, we need to set this so that it can be enabled.
 					mote.available_capabilities |= wiimote_capabilities::Extension;
+					if (mote.extension_id == 0) {
+						mote.extension_type = wiimote_extensions::Unknown;
+					}
 					dispatch_capabilities_changed(wiimote_number, callbacks);
 				}
 			}

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -49,8 +49,7 @@ namespace dolphiimote {
 				if (passthrough_mode(mote)) {
 					//Enable the motion plus normally as extension data is pointless now.
 					enable_motion_plus_no_passthrough(wiimote_number);
-				}
-				if (is_set(mote.available_capabilities, wiimote_capabilities::Extension)) {
+				} else if (is_set(mote.available_capabilities, wiimote_capabilities::Extension)) {
 					//No extension plugged in, yet we are in passthrough mode. Lets disable this.
 					mote.set_extension_disabled();
 					dispatch_capabilities_changed(wiimote_number, callbacks);
@@ -216,6 +215,7 @@ namespace dolphiimote {
 					mote.available_capabilities |= wiimote_capabilities::Extension;
 				}
 			}
+
 		}
 		else
 		{
@@ -227,9 +227,6 @@ namespace dolphiimote {
 		if (mote.extension_type == wiimote_extensions::BalanceBoard) {
 			reader.read(wiimote_number, 0xA40024, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 			reader.read(wiimote_number, 0xA40024 + 16, 8, std::bind(&capability_discoverer::handle_balanceboard_calibration2, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-		}
-		if (mote.extension_type == wiimote_extensions::Passthrough && mote.extension_id == 0) {
-			mote.extension_type = wiimote_extensions::Unknown;
 		}
 		//Appearently calibration data is stored for joysticks and things, but this is probably a pointless thing to bother calibrating for.
 		/*if (mote.extension_type == wiimote_extensions::Nunchuck) {

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -43,6 +43,11 @@ namespace dolphiimote {
 	{
 		return is_set(mote.enabled_capabilities, wiimote_capabilities::Extension | wiimote_capabilities::MotionPlus);
 	}
+	void capability_discoverer::set_led_state(int wiimote_number, int led_state) {
+		auto& mote = wiimote_states[wiimote_number];
+		mote.led_state = led_state;
+		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x11, (u8)led_state }, 3, true));
+	}
 	void capability_discoverer::handle_motion_plus_extension(int wiimote_number, bool extension_connected) {
 		auto& mote = wiimote_states[wiimote_number];
 		//If the motion plus is enabled, then this will reset the polling timer if a valid motion plus report is recieved
@@ -136,6 +141,7 @@ namespace dolphiimote {
 		if (callbacks.status_changed) {
 			dolphiimote_status status = { 0 };
 			status.battery_level = wiimote_states[wiimote_number].battery_percentage;
+			status.led_status = wiimote_states[wiimote_number].led_state;
 			callbacks.status_changed(wiimote_number, &status, callbacks.userdata);
 		}
 	}

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -314,10 +314,11 @@ namespace dolphiimote {
 		sender.write_register(wiimote_number, 0xA400F0, 0x55, 1);
 		sender.write_register(wiimote_number, 0xA400FB, 0x00, 1);
 		sender.write_register(wiimote_number, 0xA600F0, 0x55, 1);
-
-		if (wiimote_states[wiimote_number].extension_type == (dolphiimote_EXTENSION_CLASSIC_CONTROLLER
-			| dolphiimote_EXTENSION_CLASSIC_CONTROLLER_PRO | dolphiimote_EXTENSION_GUITAR_HERO_GUITAR
-			| dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS))
+		if ((wiimote_states[wiimote_number].extension_type & 
+			(wiimote_extensions::ClassicController |
+				wiimote_extensions::ClassicControllerPro |
+				wiimote_extensions::GHGuitar |
+				wiimote_extensions::GHWorldTourDrums)) == wiimote_states[wiimote_number].extension_type)
 			sender.write_register(wiimote_number, 0xA600FE, 0x07, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
 		else
 			sender.write_register(wiimote_number, 0xA600FE, 0x05, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -32,7 +32,7 @@ namespace dolphiimote {
 		if (message_type == 0x20)
 			handle_status_report(wiimote_number, data);
 
-		if (is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus)) {
+		if (is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus) && mote.extension_motion_plus_valid) {
 			//Since status reports aren't sent for passthrough extensions, we need to deal with this data seperately.
 			if (mote.extension_motion_plus_state) {
 				if (!is_set(mote.available_capabilities, wiimote_capabilities::Extension)) {
@@ -330,6 +330,7 @@ namespace dolphiimote {
 		wiimote mote = wiimote_states[wiimote_number];
 		//If we have no idea what is currently plugged into the motion plus, swap to direct to get an id, then swap back to passthrough.
 		if (mote.extension_id == 0) {
+			printf("Could not detect id, refreshing...");
 			//Swap to direct extension access
 			sender.write_register(wiimote_number, 0xA400F0, 0x55, 1, std::bind(&capability_discoverer::handle_motion_plus_passthrough_disable, this, std::placeholders::_1));
 			//temporarily use a passthrough state until we find the real id.

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -38,6 +38,7 @@ namespace dolphiimote {
 					//Even if we arent using passthrough mode, we need to set this so that it can be enabled.
 					mote.available_capabilities |= wiimote_capabilities::Extension;
 					if (mote.extension_id == 0) {
+						//Its nice to know if you have no extension vs having an extension but not knowing what it is.
 						mote.extension_type = wiimote_extensions::Unknown;
 					}
 					dispatch_capabilities_changed(wiimote_number, callbacks);
@@ -64,7 +65,6 @@ namespace dolphiimote {
 	void capability_discoverer::handle_extension_connected(int wiimote)
 	{
 		auto& mote = wiimote_states[wiimote];
-
 		if (can_unobstrusively_enable_extension(mote))
 			init_and_identify_extension_controller(wiimote);
 	}

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -119,8 +119,10 @@ namespace dolphiimote {
 	{
 		if (data.size() < 5)
 			return;
-		wiimote_states[wiimote_number].battery_percentage = (data[7]/ (float)MAX_BATTERY_VALUE)*100;
 		u8 flags = data[4];
+
+		wiimote_states[wiimote_number].battery_percentage = (data[7] / (float)MAX_BATTERY_VALUE) * 100;
+		wiimote_states[wiimote_number].led_state = flags & 0xf0;
 
 		bool battery_low = flags & 0x01;
 		bool extension_controller_connected = flags & 0x02;
@@ -131,7 +133,6 @@ namespace dolphiimote {
 		bool led_2 = flags & 0x20;
 		bool led_3 = flags & 0x40;
 		bool led_4 = flags & 0x80;
-
 		bool capabilities_changed = false;
 
 		handle_extension_controller_changed(flags & 0x02, wiimote_number, capabilities_changed);

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -19,333 +19,334 @@
 
 namespace dolphiimote {
 
-  void capability_discoverer::data_received(dolphiimote_callbacks &callbacks, int wiimote_number, checked_array<const u8> data)
-  {
-    u8 message_type = data[1];
-
-    if(message_type == 0x20)
-      handle_status_report(wiimote_number, data);
-  }
-
-  bool can_unobstrusively_enable_extension(const wiimote& mote)
-  {
-    return !is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus);
-  }
-
-  void capability_discoverer::handle_extension_connected(int wiimote)
-  {
-    auto& mote = wiimote_states[wiimote];
-
-    mote.available_capabilities |= wiimote_capabilities::Extension;
-    if(can_unobstrusively_enable_extension(mote))
-      init_and_identify_extension_controller(wiimote);
-  }
-
-  void capability_discoverer::handle_extension_disconnected(int wiimote)
-  {
-    auto& mote = wiimote_states[wiimote];
-
-    mote.available_capabilities &= ~wiimote_capabilities::Extension;
-	mote.set_extension_disabled();
-  }
-
-  bool passthrough_mode(wiimote &mote)
-  {
-    return is_set(mote.enabled_capabilities, wiimote_capabilities::Extension | wiimote_capabilities::MotionPlus);
-  }
-
-  void capability_discoverer::handle_extension_controller_changed(bool extension_controller_connected, int wiimote, bool& changed)
-  {
-    auto& mote = wiimote_states[wiimote];
-
-    if(extension_controller_connected && !is_set(mote.available_capabilities, wiimote_capabilities::Extension))
-    {
-      handle_extension_connected(wiimote);
-      changed = true;
-    }
-
-    if(!extension_controller_connected && is_set(mote.available_capabilities, wiimote_capabilities::Extension) && !passthrough_mode(mote))
-    {
-      handle_extension_disconnected(wiimote);
-      changed = true;
-    }
-  }
-
-  void capability_discoverer::handle_status_report(int wiimote_number, checked_array<const u8> data)
-  {
-    if(data.size() < 5)
-      return;
-
-    u8 flags = data[4];
-
-    bool battery_low = flags & 0x01;
-    bool extension_controller_connected = flags & 0x02;
-    bool speaker_enabled = flags & 0x04;
-    bool ir_camera_enabled = flags & 0x08;
-
-    bool led_1 = flags & 0x10;
-    bool led_2 = flags & 0x20;
-    bool led_3 = flags & 0x40;
-    bool led_4 = flags & 0x80;
-
-    bool capabilities_changed = false;
-
-    handle_extension_controller_changed(flags & 0x02, wiimote_number, capabilities_changed);
-
-    if(capabilities_changed)
-      dispatch_capabilities_changed(wiimote_number, callbacks);
-  }
-
-  void fill_capabilities(dolphiimote_capability_status &status, wiimote &mote)
-  {
-    status.available_capabilities = mote.available_capabilities;
-    status.enabled_capabilities = mote.enabled_capabilities;
-    status.extension_type = mote.extension_type;
-    status.extension_id = mote.extension_id;
-  }
-
-  void capability_discoverer::dispatch_capabilities_changed(int wiimote, dolphiimote_callbacks callbacks)
-  {
-    dolphiimote_capability_status status = { 0 };
-
-    fill_capabilities(status, wiimote_states[wiimote]);
-
-    if(callbacks.capabilities_changed)
-      callbacks.capabilities_changed(wiimote, &status, callbacks.userdata);
-  }
-
-  std::map<u64, wiimote_extensions::type> _id_to_extension_type;
-
-  std::map<u64, wiimote_extensions::type>& id_to_extension_type()
-  {
-    if(_id_to_extension_type.size() == 0)
-    {
-      _id_to_extension_type[0x000000000000] = wiimote_extensions::None;
-      _id_to_extension_type[0x0000A4200000] = wiimote_extensions::Nunchuck;
-      _id_to_extension_type[0x0000A4200505] = wiimote_extensions::Nunchuck; // Activated Wii Motion Plus in Nunchuck passthrough mode
-      _id_to_extension_type[0x0100A4200505] = wiimote_extensions::Nunchuck; // Activated Wii Motion Plus in Nunchuck passthrough mode
-      _id_to_extension_type[0xFF00A4200000] = wiimote_extensions::Nunchuck; //WEIRD - had a nunchuk that always gave off this ID. Was there any difference?
-      _id_to_extension_type[0x0000A4200101] = wiimote_extensions::ClassicController;
-      _id_to_extension_type[0x0000A4200705] = wiimote_extensions::ClassicController; // Activated Wii Motion Plus in Classic Controller passthrough mode
-      _id_to_extension_type[0x0100A4200705] = wiimote_extensions::ClassicController; // Activated Wii Motion Plus in Classic Controller passthrough mode
-      _id_to_extension_type[0x0100A4200101] = wiimote_extensions::ClassicControllerPro;
-      _id_to_extension_type[0x0000A4200103] = wiimote_extensions::GHGuitar;
-      _id_to_extension_type[0x0100A4200103] = wiimote_extensions::GHWorldTourDrums;
-	  _id_to_extension_type[0x0000A4200402] = wiimote_extensions::BalanceBoard;
-      _id_to_extension_type[0x0000A4200405] = wiimote_extensions::MotionPlus;
-      _id_to_extension_type[0x0100A4200405] = wiimote_extensions::MotionPlus;
-    }
-
-    return _id_to_extension_type;
-  }
-
-  void capability_discoverer::update_extension_type_from_id(int wiimote_number)
-  {
-    u64 id = wiimote_states[wiimote_number].extension_id;
-    
-    if (id_to_extension_type().find(id) != id_to_extension_type().end())
-      wiimote_states[wiimote_number].extension_type = id_to_extension_type()[id];
-    else if (id == 0xFFFFFFFFFFFF)
-      init_and_identify_extension_controller(wiimote_number); //Retry, because the controller extension was likely just plugged in (status report).
-    else 
-      printf("capability_discoverer::update_extension_type_from_id: id %012llx NOT FOUND\n", id);
-  }
-
-  u64 capability_discoverer::read_extension_id(checked_array<const u8> data)
-  {
-    u64 id = 0;
-
-    for(unsigned int i = 0; i < 6; i++)
-      id |= ((u64)data[5 - i]) << (i * 8);
-
-    return id;
-  }
-
-  void capability_discoverer::handle_extension_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-    u8 error_bit = reader.read_error_bit(data);
-    checked_array<const u8> extension_id = data.sub_array(7, 6);
-
-    if(error_bit == 0 && data.valid())
-    {
-      u64 id = read_extension_id(extension_id);
-      wiimote_states[wiimote_number].extension_id = id;
-      if (id == 0x0100A4200405)
-      {
-		  wiimote_states[wiimote_number].enabled_capabilities &= ~wiimote_capabilities::Extension;
-		  wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::MotionPlus;
-      }
-      else
-      {
-		  wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::Extension;
-		  wiimote_states[wiimote_number].available_capabilities |= wiimote_capabilities::Extension;
-      }
-    }
-    else
-    {
-      wiimote_states[wiimote_number].extension_id = 0;
-      wiimote_states[wiimote_number].enabled_capabilities &= ~wiimote_capabilities::Extension;
-    }
-    update_extension_type_from_id(wiimote_number);
-    dispatch_capabilities_changed(wiimote_number, callbacks);
-	
-	if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::BalanceBoard) {
-		reader.read(wiimote_number, 0xA40024, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-		reader.read(wiimote_number, 0xA40024+16, 8, std::bind(&capability_discoverer::handle_balanceboard_calibration2, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-	}
-	if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::Nunchuck) {
-		reader.read(wiimote_number, 0xA40020, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-	}
-	if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::ClassicController || wiimote_states[wiimote_number].extension_type == wiimote_extensions::ClassicControllerPro) {
-		reader.read(wiimote_number, 0xA40020, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-	}
-  }
-  void capability_discoverer::handle_classic_controller_calibration(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-	  u8 error_bit = reader.read_error_bit(data);
-	  checked_array<const u8> calib = data.sub_array(7, 16);
-  }
-  void capability_discoverer::handle_nunchuck_calibration(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-	  u8 error_bit = reader.read_error_bit(data);
-	  checked_array<const u8> calib = data.sub_array(7, 16);
-  }
-  void capability_discoverer::handle_balanceboard_calibration1(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-	  u8 error_bit = reader.read_error_bit(data);
-	  checked_array<const u8> calib = data.sub_array(7, 16);
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg0.top_right = calib[0] << 8 | calib[1];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg0.bottom_right = calib[2] << 8 | calib[3];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg0.top_left = calib[4] << 8 | calib[5];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg0.bottom_left = calib[6] << 8 | calib[7];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg17.top_right = calib[8] << 8 | calib[9];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg17.bottom_right = calib[10] << 8 | calib[11];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg17.top_left = calib[12] << 8 | calib[13];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg17.bottom_left = calib[14] << 8 | calib[15];
-  }
-  void capability_discoverer::handle_balanceboard_calibration2(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-	  u8 error_bit = reader.read_error_bit(data);
-	  checked_array<const u8> calib = data.sub_array(7, 8);
-
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg34.top_right = calib[0] << 8 | calib[1];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg34.bottom_right = calib[2] << 8 | calib[3];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg34.top_left = calib[4] << 8 | calib[5];
-	  wiimote_states[wiimote_number].calibrations.balance_board.kg34.bottom_left = calib[6] << 8 | calib[7];
-  }
-  void capability_discoverer::handle_motionplus_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
-  {
-    u8 error_bit = reader.read_error_bit(data);
-
-    if(error_bit == 0)
-    {
-      wiimote_states[wiimote_number].available_capabilities |= wiimote_capabilities::MotionPlus;      
-    }
-    else
-    {
-      wiimote_states[wiimote_number].available_capabilities &= ~wiimote_capabilities::MotionPlus;      
-    }
-
-    dispatch_capabilities_changed(wiimote_number, callbacks);
-  }
-
-  void capability_discoverer::send_extension_id_read_message(int wiimote_number)
-  {
-    reader.read(wiimote_number, 0XA400FA, 0x06, std::bind(&capability_discoverer::handle_extension_id_message, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    //According to wiibrew: Read 0xa400fa for 6 extension ID bytes.
-  }
-
-  void capability_discoverer::init_and_identify_extension_controller(int wiimote_number)
-  {
-    sender.write_register(wiimote_number, 0xA400F0, 0x55, 1);
-    sender.write_register(wiimote_number, 0xA400FB, 0x00, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
-
-    //According to wiibrew: init by writing 0x55 to 0x(4)A400F0, then writing 0x00 to 0x(4)A400FB
-  }
-
-  void capability_discoverer::determine_capabilities(int wiimote_number)
-  {
-    reader.read(wiimote_number, 0xA600FE, 0x02, std::bind(&capability_discoverer::handle_motionplus_id_message, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    //According to wiibrew: Read 0xa600fe for 2 extension ID bytes.
-    init_and_identify_extension_controller(wiimote_number);
-  }
-
-  void capability_discoverer::send_status_request(int wiimote_number)
-  {
-    //TODO: Send status report
-  }
-
-  void capability_discoverer::enable_motion_plus_no_passthrough(int wiimote_number)
-  {
-    sender.write_register(wiimote_number, 0xA400F0, 0x55, 1); 
-    sender.write_register(wiimote_number, 0xA400FB, 0x00, 1); 
-    sender.write_register(wiimote_number, 0xA600F0, 0x55, 1); 
-    sender.write_register(wiimote_number, 0xA600FE, 0x04, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
-
-    auto& mote = wiimote_states[wiimote_number];
-    mote.enabled_capabilities &= ~wiimote_capabilities::Extension;
-    mote.enabled_capabilities |= wiimote_capabilities::MotionPlus;
-  }
-
-  void capability_discoverer::enable_only_extension(int wiimote)
-  {
-    if(is_set(wiimote_states[wiimote].enabled_capabilities, wiimote_capabilities::MotionPlus))
-    {
-      sender.write_register(wiimote, 0xA400F0, 0x55, 1);  //According to Wiibrew: Writing 0x55 to 0x(4)A400F0 deactivates the MotionPlus
-      wiimote_states[wiimote].enabled_capabilities &= ~wiimote_capabilities::MotionPlus;
-    }
-
-    if(!is_set(wiimote_states[wiimote].enabled_capabilities, wiimote_capabilities::Extension))
-      init_and_identify_extension_controller(wiimote);
-  }
-
-  void capability_discoverer::enable_motion_plus_extension_passthrough(int wiimote_number)
-  {
-    sender.write_register(wiimote_number, 0xA400F0, 0x55, 1); 
-    sender.write_register(wiimote_number, 0xA400FB, 0x00, 1);
-    sender.write_register(wiimote_number, 0xA600F0, 0x55, 1);
-	
-    if (wiimote_states[wiimote_number].extension_type == ( dolphiimote_EXTENSION_CLASSIC_CONTROLLER 
-		| dolphiimote_EXTENSION_CLASSIC_CONTROLLER_PRO | dolphiimote_EXTENSION_GUITAR_HERO_GUITAR 
-		| dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS ))
-		sender.write_register(wiimote_number, 0xA600FE, 0x07, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
-    else
-		sender.write_register(wiimote_number, 0xA600FE, 0x05, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
-    /* for Classic Controller Interleave with MotionPlus, need to send 0x07, not 0x05 (numchuck)
-    sender.write_register(wiimote_number, 0xA600FE, 0x07, 1);*/
-
-    wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::MotionPlus | wiimote_capabilities::Extension;
-  }
-
-  void capability_discoverer::handle_motion_plus_and_extension_enabling(int wiimote_number, wiimote_capabilities::type capabilities_to_enable)
-  {
-    if((capabilities_to_enable & wiimote_capabilities::Extension) && (capabilities_to_enable & wiimote_capabilities::MotionPlus))
-      enable_motion_plus_extension_passthrough(wiimote_number);
-    else if(is_set(capabilities_to_enable, wiimote_capabilities::Extension))
-      enable_only_extension(wiimote_number);
-    else if(is_set(capabilities_to_enable, wiimote_capabilities::MotionPlus))
-      enable_motion_plus_no_passthrough(wiimote_number);
-    else
-    {
-      //Don't really need to disable; doesn't hurt.
-    }
-  }
-
-  void capability_discoverer::enable(int wiimote_number, wiimote_capabilities::type capabilities_to_enable)
-  {
-    if(capabilities_to_enable == wiimote_states[wiimote_number].enabled_capabilities)
+	void capability_discoverer::data_received(dolphiimote_callbacks &callbacks, int wiimote_number, checked_array<const u8> data)
 	{
-		printf("capability_discoverer::enable: Capabilities already enabled\n");
-		return;
-	}
-	
-    if((capabilities_to_enable & wiimote_states[wiimote_number].available_capabilities) != capabilities_to_enable)
-	{
-		printf("capability_discoverer::enable: Capabilities not available to enable. Checking capabilities\n");
-		determine_capabilities(wiimote_number);
-		return;
+		u8 message_type = data[1];
+
+		if (message_type == 0x20)
+			handle_status_report(wiimote_number, data);
 	}
 
-    handle_motion_plus_and_extension_enabling(wiimote_number, capabilities_to_enable);
-  }
+	bool can_unobstrusively_enable_extension(const wiimote& mote)
+	{
+		return !is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus);
+	}
+
+	void capability_discoverer::handle_extension_connected(int wiimote)
+	{
+		auto& mote = wiimote_states[wiimote];
+
+		mote.available_capabilities |= wiimote_capabilities::Extension;
+		if (can_unobstrusively_enable_extension(mote))
+			init_and_identify_extension_controller(wiimote);
+	}
+
+	void capability_discoverer::handle_extension_disconnected(int wiimote)
+	{
+		auto& mote = wiimote_states[wiimote];
+
+		mote.available_capabilities &= ~wiimote_capabilities::Extension;
+		mote.set_extension_disabled();
+	}
+
+	bool passthrough_mode(wiimote &mote)
+	{
+		return is_set(mote.enabled_capabilities, wiimote_capabilities::Extension | wiimote_capabilities::MotionPlus);
+	}
+
+	void capability_discoverer::handle_extension_controller_changed(bool extension_controller_connected, int wiimote, bool& changed)
+	{
+		auto& mote = wiimote_states[wiimote];
+
+		if (extension_controller_connected && !is_set(mote.available_capabilities, wiimote_capabilities::Extension))
+		{
+			handle_extension_connected(wiimote);
+			changed = true;
+		}
+
+		if (!extension_controller_connected && is_set(mote.available_capabilities, wiimote_capabilities::Extension) && !passthrough_mode(mote))
+		{
+			handle_extension_disconnected(wiimote);
+			changed = true;
+		}
+	}
+
+	void capability_discoverer::handle_status_report(int wiimote_number, checked_array<const u8> data)
+	{
+		if (data.size() < 5)
+			return;
+
+		u8 flags = data[4];
+
+		bool battery_low = flags & 0x01;
+		bool extension_controller_connected = flags & 0x02;
+		bool speaker_enabled = flags & 0x04;
+		bool ir_camera_enabled = flags & 0x08;
+
+		bool led_1 = flags & 0x10;
+		bool led_2 = flags & 0x20;
+		bool led_3 = flags & 0x40;
+		bool led_4 = flags & 0x80;
+
+		bool capabilities_changed = false;
+
+		handle_extension_controller_changed(flags & 0x02, wiimote_number, capabilities_changed);
+
+		if (capabilities_changed)
+			dispatch_capabilities_changed(wiimote_number, callbacks);
+	}
+
+	void fill_capabilities(dolphiimote_capability_status &status, wiimote &mote)
+	{
+		status.available_capabilities = mote.available_capabilities;
+		status.enabled_capabilities = mote.enabled_capabilities;
+		status.extension_type = mote.extension_type;
+		status.extension_id = mote.extension_id;
+	}
+
+	void capability_discoverer::dispatch_capabilities_changed(int wiimote, dolphiimote_callbacks callbacks)
+	{
+		dolphiimote_capability_status status = { 0 };
+
+		fill_capabilities(status, wiimote_states[wiimote]);
+
+		if (callbacks.capabilities_changed)
+			callbacks.capabilities_changed(wiimote, &status, callbacks.userdata);
+	}
+
+	std::map<u64, wiimote_extensions::type> _id_to_extension_type;
+
+	std::map<u64, wiimote_extensions::type>& id_to_extension_type()
+	{
+		if (_id_to_extension_type.size() == 0)
+		{
+			_id_to_extension_type[0x000000000000] = wiimote_extensions::None;
+			_id_to_extension_type[0x0000A4200000] = wiimote_extensions::Nunchuck;
+			_id_to_extension_type[0x0000A4200505] = wiimote_extensions::Passthrough; // Activated Wii Motion Plus in Nunchuck passthrough mode
+			_id_to_extension_type[0x0100A4200505] = wiimote_extensions::Passthrough; // Activated Wii Motion Plus in Nunchuck passthrough mode
+			_id_to_extension_type[0xFF00A4200000] = wiimote_extensions::Nunchuck; //WEIRD - had a nunchuk that always gave off this ID. Was there any difference?
+			_id_to_extension_type[0x0000A4200101] = wiimote_extensions::ClassicController;
+			_id_to_extension_type[0x0000A4200705] = wiimote_extensions::ClassicController; // Activated Wii Motion Plus in Classic Controller passthrough mode
+			_id_to_extension_type[0x0100A4200705] = wiimote_extensions::ClassicController; // Activated Wii Motion Plus in Classic Controller passthrough mode
+			_id_to_extension_type[0x0100A4200101] = wiimote_extensions::ClassicControllerPro;
+			_id_to_extension_type[0x0000A4200103] = wiimote_extensions::GHGuitar;
+			_id_to_extension_type[0x0100A4200103] = wiimote_extensions::GHWorldTourDrums;
+			_id_to_extension_type[0x0000A4200402] = wiimote_extensions::BalanceBoard;
+			_id_to_extension_type[0x0000A4200405] = wiimote_extensions::MotionPlus;
+			_id_to_extension_type[0x0100A4200405] = wiimote_extensions::MotionPlus;
+		}
+
+		return _id_to_extension_type;
+	}
+	wiimote_extensions::type get_type_from_id(u64 id) {
+		if (id_to_extension_type().find(id) != id_to_extension_type().end())
+			return id_to_extension_type()[id];
+		return wiimote_extensions::None;
+	}
+	void capability_discoverer::update_extension_type_from_id(int wiimote_number)
+	{
+		u64 id = wiimote_states[wiimote_number].extension_id;
+		if (id_to_extension_type().find(id) != id_to_extension_type().end())
+			wiimote_states[wiimote_number].extension_type = id_to_extension_type()[id];
+		else if (id == 0xFFFFFFFFFFFF)
+			init_and_identify_extension_controller(wiimote_number); //Retry, because the controller extension was likely just plugged in (status report).
+		else
+			printf("capability_discoverer::update_extension_type_from_id: id %012llx NOT FOUND\n", id);
+	}
+
+	u64 capability_discoverer::read_extension_id(checked_array<const u8> data)
+	{
+		u64 id = 0;
+
+		for (unsigned int i = 0; i < 6; i++)
+			id |= ((u64)data[5 - i]) << (i * 8);
+
+		return id;
+	}
+
+	void capability_discoverer::handle_extension_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
+	{
+		u8 error_bit = reader.read_error_bit(data);
+		checked_array<const u8> extension_id = data.sub_array(7, 6);
+
+		if (error_bit == 0 && data.valid())
+		{
+			u64 id = read_extension_id(extension_id);
+			//When we get a passthrough id, don't override any settings!
+			if (!(get_type_from_id(id) == wiimote_extensions::Passthrough)) {
+				wiimote_states[wiimote_number].extension_id = id;
+				if (id == 0x0100A4200405)
+				{
+					wiimote_states[wiimote_number].enabled_capabilities &= ~wiimote_capabilities::Extension;
+					wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::MotionPlus;
+				}
+				else
+				{
+					wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::Extension;
+					wiimote_states[wiimote_number].available_capabilities |= wiimote_capabilities::Extension;
+				}
+			}
+			else {
+				wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::Extension;
+				wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::MotionPlus;
+			}
+		}
+		else
+		{
+			wiimote_states[wiimote_number].extension_id = 0;
+			wiimote_states[wiimote_number].enabled_capabilities &= ~wiimote_capabilities::Extension;
+		}
+		update_extension_type_from_id(wiimote_number);
+		dispatch_capabilities_changed(wiimote_number, callbacks);
+
+		if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::BalanceBoard) {
+			reader.read(wiimote_number, 0xA40024, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+			reader.read(wiimote_number, 0xA40024 + 16, 8, std::bind(&capability_discoverer::handle_balanceboard_calibration2, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+		}
+		//Appearently calibration data is stored for joysticks and things, but this is probably a pointless thing to bother calibrating for.
+		/*if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::Nunchuck) {
+			reader.read(wiimote_number, 0xA40020, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+		}
+		if (wiimote_states[wiimote_number].extension_type == wiimote_extensions::ClassicController || wiimote_states[wiimote_number].extension_type == wiimote_extensions::ClassicControllerPro) {
+			reader.read(wiimote_number, 0xA40020, 16, std::bind(&capability_discoverer::handle_balanceboard_calibration1, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+		}*/
+	}
+	void capability_discoverer::handle_balanceboard_calibration1(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
+	{
+		u8 error_bit = reader.read_error_bit(data);
+		checked_array<const u8> calib = data.sub_array(7, 16);
+		wiimote_states[wiimote_number].calibrations.balance_board.kg0.top_right = calib[0] << 8 | calib[1];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg0.bottom_right = calib[2] << 8 | calib[3];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg0.top_left = calib[4] << 8 | calib[5];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg0.bottom_left = calib[6] << 8 | calib[7];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg17.top_right = calib[8] << 8 | calib[9];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg17.bottom_right = calib[10] << 8 | calib[11];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg17.top_left = calib[12] << 8 | calib[13];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg17.bottom_left = calib[14] << 8 | calib[15];
+	}
+	void capability_discoverer::handle_balanceboard_calibration2(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
+	{
+		u8 error_bit = reader.read_error_bit(data);
+		checked_array<const u8> calib = data.sub_array(7, 8);
+
+		wiimote_states[wiimote_number].calibrations.balance_board.kg34.top_right = calib[0] << 8 | calib[1];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg34.bottom_right = calib[2] << 8 | calib[3];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg34.top_left = calib[4] << 8 | calib[5];
+		wiimote_states[wiimote_number].calibrations.balance_board.kg34.bottom_left = calib[6] << 8 | calib[7];
+	}
+	void capability_discoverer::handle_motionplus_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks)
+	{
+		u8 error_bit = reader.read_error_bit(data);
+
+		if (error_bit == 0)
+		{
+			wiimote_states[wiimote_number].available_capabilities |= wiimote_capabilities::MotionPlus;
+		}
+		else
+		{
+			wiimote_states[wiimote_number].available_capabilities &= ~wiimote_capabilities::MotionPlus;
+		}
+
+		dispatch_capabilities_changed(wiimote_number, callbacks);
+	}
+
+	void capability_discoverer::send_extension_id_read_message(int wiimote_number)
+	{
+		reader.read(wiimote_number, 0XA400FA, 0x06, std::bind(&capability_discoverer::handle_extension_id_message, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+		//According to wiibrew: Read 0xa400fa for 6 extension ID bytes.
+	}
+
+	void capability_discoverer::init_and_identify_extension_controller(int wiimote_number)
+	{
+		sender.write_register(wiimote_number, 0xA400F0, 0x55, 1);
+		sender.write_register(wiimote_number, 0xA400FB, 0x00, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
+
+		//According to wiibrew: init by writing 0x55 to 0x(4)A400F0, then writing 0x00 to 0x(4)A400FB
+	}
+
+	void capability_discoverer::determine_capabilities(int wiimote_number)
+	{
+		reader.read(wiimote_number, 0xA600FE, 0x02, std::bind(&capability_discoverer::handle_motionplus_id_message, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+		//According to wiibrew: Read 0xa600fe for 2 extension ID bytes.
+		init_and_identify_extension_controller(wiimote_number);
+	}
+
+	void capability_discoverer::send_status_request(int wiimote_number)
+	{
+		//TODO: Send status report
+	}
+
+	void capability_discoverer::enable_motion_plus_no_passthrough(int wiimote_number)
+	{
+		sender.write_register(wiimote_number, 0xA400F0, 0x55, 1);
+		sender.write_register(wiimote_number, 0xA400FB, 0x00, 1);
+		sender.write_register(wiimote_number, 0xA600F0, 0x55, 1);
+		sender.write_register(wiimote_number, 0xA600FE, 0x04, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
+
+		auto& mote = wiimote_states[wiimote_number];
+		mote.enabled_capabilities &= ~wiimote_capabilities::Extension;
+		mote.enabled_capabilities |= wiimote_capabilities::MotionPlus;
+	}
+
+	void capability_discoverer::enable_only_extension(int wiimote)
+	{
+		if (is_set(wiimote_states[wiimote].enabled_capabilities, wiimote_capabilities::MotionPlus))
+		{
+			sender.write_register(wiimote, 0xA400F0, 0x55, 1);  //According to Wiibrew: Writing 0x55 to 0x(4)A400F0 deactivates the MotionPlus
+			wiimote_states[wiimote].enabled_capabilities &= ~wiimote_capabilities::MotionPlus;
+		}
+
+		if (!is_set(wiimote_states[wiimote].enabled_capabilities, wiimote_capabilities::Extension))
+			init_and_identify_extension_controller(wiimote);
+	}
+
+	void capability_discoverer::enable_motion_plus_extension_passthrough(int wiimote_number)
+	{
+		sender.write_register(wiimote_number, 0xA400F0, 0x55, 1);
+		sender.write_register(wiimote_number, 0xA400FB, 0x00, 1);
+		sender.write_register(wiimote_number, 0xA600F0, 0x55, 1);
+
+		if (wiimote_states[wiimote_number].extension_type == (dolphiimote_EXTENSION_CLASSIC_CONTROLLER
+			| dolphiimote_EXTENSION_CLASSIC_CONTROLLER_PRO | dolphiimote_EXTENSION_GUITAR_HERO_GUITAR
+			| dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS))
+			sender.write_register(wiimote_number, 0xA600FE, 0x07, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
+		else
+			sender.write_register(wiimote_number, 0xA600FE, 0x05, 1, std::bind(&capability_discoverer::send_extension_id_read_message, this, std::placeholders::_1));
+		/* for Classic Controller Interleave with MotionPlus, need to send 0x07, not 0x05 (numchuck)
+		sender.write_register(wiimote_number, 0xA600FE, 0x07, 1);*/
+
+		wiimote_states[wiimote_number].enabled_capabilities |= wiimote_capabilities::MotionPlus | wiimote_capabilities::Extension;
+	}
+
+	void capability_discoverer::handle_motion_plus_and_extension_enabling(int wiimote_number, wiimote_capabilities::type capabilities_to_enable)
+	{
+		if ((capabilities_to_enable & wiimote_capabilities::Extension) && (capabilities_to_enable & wiimote_capabilities::MotionPlus))
+			enable_motion_plus_extension_passthrough(wiimote_number);
+		else if (is_set(capabilities_to_enable, wiimote_capabilities::Extension))
+			enable_only_extension(wiimote_number);
+		else if (is_set(capabilities_to_enable, wiimote_capabilities::MotionPlus))
+			enable_motion_plus_no_passthrough(wiimote_number);
+		else
+		{
+			//Don't really need to disable; doesn't hurt.
+		}
+	}
+
+	void capability_discoverer::enable(int wiimote_number, wiimote_capabilities::type capabilities_to_enable)
+	{
+		if (capabilities_to_enable == wiimote_states[wiimote_number].enabled_capabilities)
+		{
+			printf("capability_discoverer::enable: Capabilities already enabled\n");
+			return;
+		}
+
+		if ((capabilities_to_enable & wiimote_states[wiimote_number].available_capabilities) != capabilities_to_enable)
+		{
+			printf("capability_discoverer::enable: Capabilities not available to enable. Checking capabilities\n");
+			determine_capabilities(wiimote_number);
+			return;
+		}
+
+		handle_motion_plus_and_extension_enabling(wiimote_number, capabilities_to_enable);
+	}
 }

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -134,7 +134,7 @@ namespace dolphiimote {
 		fill_capabilities(status, wiimote_states[wiimote]);
 
 		if (callbacks.capabilities_changed) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			std::this_thread::sleep_for(std::chrono::milliseconds(150));
 			callbacks.capabilities_changed(wiimote, &status, callbacks.userdata);
 		}
 	}
@@ -198,24 +198,22 @@ namespace dolphiimote {
 		if (error_bit == 0 && data.valid())
 		{
 			u64 id = read_extension_id(extension_id);
+			wiimote_extensions::type type = get_type_from_id(id);
 			//When we get a passthrough id, don't override the current extension id!
-			if (get_type_from_id(id) == wiimote_extensions::Passthrough) {
+			if (type == wiimote_extensions::Passthrough) {
 				mote.enabled_capabilities |= wiimote_capabilities::Extension;
 				mote.enabled_capabilities |= wiimote_capabilities::MotionPlus;
 			}
-			else {
-				if (id == 0x0100A4200405)
-				{
-					mote.enabled_capabilities |= wiimote_capabilities::MotionPlus;
-				}
-				else if (!(get_type_from_id(id) == wiimote_extensions::MotionPlus))
-				{
-					mote.extension_id = id;
-					mote.enabled_capabilities |= wiimote_capabilities::Extension;
-					mote.available_capabilities |= wiimote_capabilities::Extension;
-				}
+			else if (type == wiimote_extensions::MotionPlus)
+			{
+				mote.enabled_capabilities |= wiimote_capabilities::MotionPlus;
 			}
-
+			else 
+			{
+				mote.extension_id = id;
+				mote.enabled_capabilities |= wiimote_capabilities::Extension;
+				mote.available_capabilities |= wiimote_capabilities::Extension;
+			}
 		}
 		else
 		{

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -30,15 +30,13 @@ namespace dolphiimote {
 
 		if (message_type == 0x20)
 			handle_status_report(wiimote_number, data);
-		if (is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus)) {
-			if (!mote.extension_motion_plus_state && is_set(mote.enabled_capabilities, wiimote_capabilities::Extension)) {
-				mote.available_capabilities &= ~wiimote_capabilities::Extension;
-				enable_motion_plus_no_passthrough(wiimote_number);
-			}
-			if (mote.extension_motion_plus_state && !is_set(mote.available_capabilities, wiimote_capabilities::Extension)) {
-				mote.available_capabilities |= wiimote_capabilities::Extension;
-				enable_only_extension(wiimote_number);
-			}
+
+		if (!mote.extension_motion_plus_state && is_set(mote.available_capabilities, wiimote_capabilities::MotionPlus)) {
+			mote.available_capabilities &= ~wiimote_capabilities::Extension;
+			mote.enabled_capabilities &= ~wiimote_capabilities::Extension;
+			mote.extension_motion_plus_state = true;
+			dispatch_capabilities_changed(wiimote_number, callbacks);
+			enable_only_extension(wiimote_number);
 		}
 	}
 

--- a/DolphiiMote/Core/capability_discoverer.h
+++ b/DolphiiMote/Core/capability_discoverer.h
@@ -44,8 +44,6 @@ namespace dolphiimote
     virtual void handle_extension_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
 	virtual void handle_balanceboard_calibration1(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
 	virtual void handle_balanceboard_calibration2(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
-	virtual void handle_nunchuck_calibration(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
-	virtual void handle_classic_controller_calibration(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
     virtual void handle_motionplus_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
     virtual void init_and_identify_extension_controller(int wiimote_number);
     virtual void send_extension_id_read_message(int wiimote_number);

--- a/DolphiiMote/Core/capability_discoverer.h
+++ b/DolphiiMote/Core/capability_discoverer.h
@@ -36,6 +36,7 @@ namespace dolphiimote
 
     virtual void init_and_identify_extension_controller(int wiimote_number);
     virtual void send_status_request(int wiimote_number);
+	virtual void set_led_state(int wiimote_number, int led_state);
     virtual void enable(int wiimote_number, wiimote_capabilities::type capabilities_to_enable);
 	virtual void handle_motion_plus_extension(int wiimote_number, bool extension_connected);
 

--- a/DolphiiMote/Core/capability_discoverer.h
+++ b/DolphiiMote/Core/capability_discoverer.h
@@ -50,7 +50,8 @@ namespace dolphiimote
     virtual void dispatch_capabilities_changed(int wiimote, dolphiimote_callbacks callbacks);
     virtual void handle_motion_plus_and_extension_enabling(int wiimote_number, wiimote_capabilities::type capabilities_to_enable);
     virtual void handle_extension_controller_changed(bool extension_controller_connected, int wiimote, bool& changed);
-
+	virtual void handle_motion_plus_passthrough_disable(int wiimote_number);
+	virtual void handle_motion_plus_extension_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
     virtual void enable_motion_plus_no_passthrough(int wiimote_number);
     virtual void enable_motion_plus_extension_passthrough(int wiimote_number);
     virtual void enable_only_extension(int wiimote);

--- a/DolphiiMote/Core/capability_discoverer.h
+++ b/DolphiiMote/Core/capability_discoverer.h
@@ -34,18 +34,20 @@ namespace dolphiimote
 
     virtual void data_received(dolphiimote_callbacks &callbacks, int wiimote_number, checked_array<const u8> data);
 
-    virtual void determine_capabilities(int wiimote_number);
+    virtual void init_and_identify_extension_controller(int wiimote_number);
     virtual void send_status_request(int wiimote_number);
     virtual void enable(int wiimote_number, wiimote_capabilities::type capabilities_to_enable);
+	virtual void handle_motion_plus_extension(int wiimote_number, bool extension_connected);
 
   protected:
-    virtual void handle_status_report(int wiimote_number, checked_array<const u8> data);
+    virtual void handle_status_report(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
     virtual void update_extension_type_from_id(int wiimote_number);
     virtual void handle_extension_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
+	virtual void handle_extension_id_message_test(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
+	virtual void handle_extension_id_message_test2(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
 	virtual void handle_balanceboard_calibration1(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
 	virtual void handle_balanceboard_calibration2(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
     virtual void handle_motionplus_id_message(int wiimote_number, checked_array<const u8> data, dolphiimote_callbacks callbacks);
-    virtual void init_and_identify_extension_controller(int wiimote_number);
     virtual void send_extension_id_read_message(int wiimote_number);
     virtual void dispatch_capabilities_changed(int wiimote, dolphiimote_callbacks callbacks);
     virtual void handle_motion_plus_and_extension_enabling(int wiimote_number, wiimote_capabilities::type capabilities_to_enable);

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -130,23 +130,24 @@ namespace dolphiimote {
 
     void data_reporter::handle_data_reporting(dolphiimote_callbacks &callbacks, int wiimote_number, u8 reporting_mode, checked_array<const u8> data)
     {
+	  wiimote& mote = wiimote_states[wiimote_number];
       dolphiimote_wiimote_data wiimote_data = { 0 };
 
-      retrieve_standard_data(reporting_mode, wiimote_states[wiimote_number], data, wiimote_data);
+      retrieve_standard_data(reporting_mode, mote, data, wiimote_data);
 
       if(reporting_mode_extension_data_offset.find(reporting_mode) != reporting_mode_extension_data_offset.end())
       {
         retrieve_extension_data(wiimote_number,
-                                wiimote_states[wiimote_number],
+			mote,
                                 data.sub_array(reporting_mode_extension_data_offset[reporting_mode].offset,
                                                reporting_mode_extension_data_offset[reporting_mode].size),
                                 wiimote_data);
       }
-
 	  if (wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID) {
-		  wiimote_states[wiimote_number].extension_motion_plus_state = wiimote_data.motionplus.extension_connected;
+		  mote.extension_motion_plus_state = wiimote_data.motionplus.extension_connected;
 	  }
-	  wiimote_states[wiimote_number].extension_motion_plus_valid = wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID;
+	  wiimote_data.status.battery_level = mote.battery_percentage;
+	  mote.extension_motion_plus_valid = wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID;
       if(callbacks.data_received != nullptr)
         callbacks.data_received(wiimote_number, &wiimote_data, callbacks.userdata);
     }

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -42,6 +42,10 @@ namespace dolphiimote {
 	{
 		return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::GHGuitar)(mote) && !motion_plus_filter()(mote); };
 	}
+	std::function<bool(const wiimote&)> interleaved_guitar_filter()
+	{
+		return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::GHGuitar)(mote) && motion_plus_filter()(mote); };
+	}
 
     std::function<bool(const wiimote&)> nunchuck_filter()
     {
@@ -75,6 +79,7 @@ namespace dolphiimote {
       extension_retrievers.push_back(std::make_pair(classic_controller_filter(), serialization::retrieve_classic_controller));
       extension_retrievers.push_back(std::make_pair(interleaved_classic_controller_filter(), serialization::retrieve_interleaved_classic_controller));
 	  extension_retrievers.push_back(std::make_pair(guitar_filter(), serialization::retrieve_guitar));
+	  extension_retrievers.push_back(std::make_pair(interleaved_guitar_filter(), serialization::retrieve_interleaved_guitar));
 	  extension_retrievers.push_back(std::make_pair(balance_board_filter(), serialization::retrieve_balance_board));
     }
 

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -33,6 +33,7 @@ namespace dolphiimote {
     {
       return [=](const wiimote& mote) { return is_set(mote.enabled_capabilities, wiimote_capabilities::MotionPlus); };
     }
+
 	std::function<bool(const wiimote&)> balance_board_filter()
 	{
 		return [=](const wiimote& mote) { return standard_extension_filter(wiimote_extensions::BalanceBoard)(mote) && !motion_plus_filter()(mote); };
@@ -116,11 +117,18 @@ namespace dolphiimote {
 
     void retrieve_extension_data(int wiimote_number, wiimote& state, checked_array<const u8> data, dolphiimote_wiimote_data &output)
     {
-      wiimote_extensions::type enabled_extension = state.extension_type;
-
       for(auto & pair : extension_retrievers)
         if(pair.first(state))
           pair.second(data, state, output);
+
+	  if (output.valid_data_flags & dolphiimote_MOTIONPLUS_VALID) {
+		  if (output.motionplus.extension_connected) {
+			  state.available_capabilities |= wiimote_capabilities::Extension;
+		  }
+		  else {
+			  state.available_capabilities &= ~wiimote_capabilities::Extension;
+		  }
+	  }
     }
 
     void data_reporter::handle_data_reporting(dolphiimote_callbacks &callbacks, int wiimote_number, u8 reporting_mode, checked_array<const u8> data)

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -121,14 +121,6 @@ namespace dolphiimote {
         if(pair.first(state))
           pair.second(data, state, output);
 
-	  if (output.valid_data_flags & dolphiimote_MOTIONPLUS_VALID) {
-		  if (output.motionplus.extension_connected) {
-			  state.available_capabilities |= wiimote_capabilities::Extension;
-		  }
-		  else {
-			  state.available_capabilities &= ~wiimote_capabilities::Extension;
-		  }
-	  }
     }
 
     void data_reporter::handle_data_reporting(dolphiimote_callbacks &callbacks, int wiimote_number, u8 reporting_mode, checked_array<const u8> data)
@@ -146,6 +138,9 @@ namespace dolphiimote {
                                 wiimote_data);
       }
 
+	  if (wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID) {
+		  wiimote_states[wiimote_number].extension_motion_plus_state = wiimote_data.motionplus.extension_connected;
+	  }
       if(callbacks.data_received != nullptr)
         callbacks.data_received(wiimote_number, &wiimote_data, callbacks.userdata);
     }

--- a/DolphiiMote/Core/data_reporter.cpp
+++ b/DolphiiMote/Core/data_reporter.cpp
@@ -146,6 +146,7 @@ namespace dolphiimote {
 	  if (wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID) {
 		  wiimote_states[wiimote_number].extension_motion_plus_state = wiimote_data.motionplus.extension_connected;
 	  }
+	  wiimote_states[wiimote_number].extension_motion_plus_valid = wiimote_data.valid_data_flags & dolphiimote_MOTIONPLUS_VALID;
       if(callbacks.data_received != nullptr)
         callbacks.data_received(wiimote_number, &wiimote_data, callbacks.userdata);
     }

--- a/DolphiiMote/Core/data_reporter.h
+++ b/DolphiiMote/Core/data_reporter.h
@@ -21,20 +21,23 @@
 #include "wiimote.h"
 #include "dolphiimote.h"
 #include "data_sender.h"
+#include "capability_discoverer.h"
 #include "Util/collections.h"
 
 namespace dolphiimote {  
   class data_reporter : public wiimote_data_handler
   {
   public:
-    data_reporter(std::map<int, wiimote> &wiimote_states, data_sender &sender) : wiimote_states(wiimote_states), sender(sender)
+    data_reporter(std::map<int, wiimote> &wiimote_states, data_sender &sender, capability_discoverer &discoverer) : wiimote_states(wiimote_states), sender(sender), discoverer(discoverer)
     { }
     void data_received(dolphiimote_callbacks &callbacks, int wiimote_number, checked_array<const u8> data);
     void request_reporting_mode(int wiimote_number, u8 reporting_mode);
+
   private:
     std::map<int, wiimote> &wiimote_states;
     data_sender &sender;
-
+	capability_discoverer &discoverer;
+	void retrieve_extension_data(int wiimote_number, wiimote& state, checked_array<const u8> data, dolphiimote_wiimote_data &output);
     void handle_data_reporting(dolphiimote_callbacks &callbacks, int wiimote_number, u8 reporting_mode, checked_array<const u8> data);
   };
 }

--- a/DolphiiMote/Core/dolphiimote.cpp
+++ b/DolphiiMote/Core/dolphiimote.cpp
@@ -35,9 +35,15 @@ void dolphiimote_brief_rumble(uint8_t  wiimote_number)
   if(!host)
     return;
 
-  host->do_rumble(wiimote_number);
+  host->do_brief_rumble(wiimote_number);
 }
+void dolphiimote_set_rumble(uint8_t  wiimote_number, uint8_t enable)
+{
+	if (!host)
+		return;
 
+	host->do_rumble(wiimote_number, enable);
+}
 void dolphiimote_enable_capabilities(uint8_t wiimote_number, dolphiimote_capabilities capabilities)
 {
   if(!host)

--- a/DolphiiMote/Core/dolphiimote.cpp
+++ b/DolphiiMote/Core/dolphiimote.cpp
@@ -26,7 +26,6 @@ int dolphiimote_init(dolphiimote_callbacks _callback)
 {
   host = std::shared_ptr<dolphiimote::dolphiimote_host>(new dolphiimote::dolphiimote_host(_callback));
   WiimoteReal::listeners.add(std::weak_ptr<WiimoteReal::wiimote_listener>(host));
-
   return host->number_of_wiimotes();
 }
 
@@ -44,20 +43,19 @@ void dolphiimote_set_rumble(uint8_t  wiimote_number, uint8_t enable)
 
 	host->do_rumble(wiimote_number, enable);
 }
+void dolphiimote_request_status(uint8_t  wiimote_number)
+{
+	if (!host)
+		return;
+
+	host->request_status(wiimote_number);
+}
 void dolphiimote_enable_capabilities(uint8_t wiimote_number, dolphiimote_capabilities capabilities)
 {
   if(!host)
     return;
 
   host->enable_capabilities(wiimote_number, (dolphiimote::wiimote_capabilities::type)capabilities);
-}
-
-void dolphiimote_determine_capabilities(uint8_t wiimote_number)
-{
-  if(!host)
-    return;
-
-  host->determine_capabilities(wiimote_number);
 }
 
 void dolphiimote_set_reporting_mode(uint8_t wiimote_number, uint8_t mode)

--- a/DolphiiMote/Core/dolphiimote.cpp
+++ b/DolphiiMote/Core/dolphiimote.cpp
@@ -43,6 +43,13 @@ void dolphiimote_set_rumble(uint8_t  wiimote_number, uint8_t enable)
 
 	host->do_rumble(wiimote_number, enable);
 }
+void dolphiimote_set_leds(uint8_t  wiimote_number, uint8_t leds)
+{
+	if (!host)
+		return;
+
+	host->set_leds(wiimote_number, leds);
+}
 void dolphiimote_request_status(uint8_t  wiimote_number)
 {
 	if (!host)

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -131,6 +131,7 @@ typedef struct dolphiimote_guitar
 typedef struct dolphiimote_status
 {
 	uint8_t battery_level;
+	uint8_t led_status;
 
 } dolphiimote_status;
 typedef struct dolphiimote_wiimote_data
@@ -228,6 +229,10 @@ void dolphiimote_set_rumble(uint8_t wiimote_number, uint8_t enable);
 */
 void dolphiimote_request_status(uint8_t wiimote_number);
 
+/*
+  Set the state of the leds
+*/
+void dolphiimote_set_leds(uint8_t wiimote_number, uint8_t leds);
 /*
   Enable different features of the wiimote.
 */

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -295,7 +295,7 @@ dolphiimote_GUITAR_BUTTON_* are the Classic Controller buttons, as they are save
 #define dolphiimote_GUITAR_BUTTON_STRUM_DOWN 0x4000
 #define dolphiimote_GUITAR_BUTTON_STRUM_UP 0x0001
 
-#define dolphiimote_GUITAR_BUTTON_Green 0x0010
+#define dolphiimote_GUITAR_BUTTON_GREEN 0x0010
 #define dolphiimote_GUITAR_BUTTON_RED 0x0040
 #define dolphiimote_GUITAR_BUTTON_YELLOW 0x0008
 #define dolphiimote_GUITAR_BUTTON_BLUE 0x0020

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -145,8 +145,6 @@ typedef struct dolphiimote_wiimote_data
   dolphiimote_classic_controller classic_controller;
   dolphiimote_guitar guitar;
   dolphiimote_balance_board balance_board;
-  dolphiimote_status status;
-
 
 } dolphiimote_wiimote_data;
 
@@ -161,6 +159,7 @@ typedef struct dolphiimote_capability_status
 
 typedef void (*update_callback_t)(uint8_t wiimote_number, struct dolphiimote_wiimote_data *data_struct, void *userdata);
 typedef void (*connection_callback_t)(uint8_t wiimote_number, int connected);
+typedef void (*status_callback_t)(uint8_t wiimote_number, struct dolphiimote_status *data_struct, void *userdata);
 typedef void (*capabilities_callback_t)(uint8_t wiimote_number, struct dolphiimote_capability_status *capabilities, void *userdata);
 typedef void (*log_callback_t)(const char* str, uint32_t size);
 
@@ -178,6 +177,7 @@ typedef struct dolphiimote_callbacks
   update_callback_t data_received;
   connection_callback_t connection_changed;
   capabilities_callback_t capabilities_changed;
+  status_callback_t status_changed;
   log_callback_t log_received;
 
   void *userdata;
@@ -224,9 +224,9 @@ void dolphiimote_brief_rumble(uint8_t wiimote_number);
 */
 void dolphiimote_set_rumble(uint8_t wiimote_number, uint8_t enable);
 /*
-  Start a check for the current capabilities of the wiimote.
+  Request a status report from the wiimote (battery percentage, etc.)
 */
-void dolphiimote_determine_capabilities(uint8_t wiimote_number);
+void dolphiimote_request_status(uint8_t wiimote_number);
 
 /*
   Enable different features of the wiimote.

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -128,6 +128,11 @@ typedef struct dolphiimote_guitar
 	uint16_t buttons;
 
 } dolphiimote_guitar;
+typedef struct dolphiimote_status
+{
+	uint8_t battery_level;
+
+} dolphiimote_status;
 typedef struct dolphiimote_wiimote_data
 {  
   dolphiimote_button_state button_state;
@@ -140,6 +145,8 @@ typedef struct dolphiimote_wiimote_data
   dolphiimote_classic_controller classic_controller;
   dolphiimote_guitar guitar;
   dolphiimote_balance_board balance_board;
+  dolphiimote_status status;
+
 
 } dolphiimote_wiimote_data;
 
@@ -212,6 +219,10 @@ void dolphiimote_set_reporting_mode(uint8_t wiimote_number, uint8_t mode);
 */
 void dolphiimote_brief_rumble(uint8_t wiimote_number);
 
+/*
+  Set rumble state to enabled
+*/
+void dolphiimote_set_rumble(uint8_t wiimote_number, uint8_t enable);
 /*
   Start a check for the current capabilities of the wiimote.
 */

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -315,6 +315,7 @@ dolphiimote_GUITAR_BUTTON_* are the Classic Controller buttons, as they are save
 #define dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS 0x0010
 #define dolphiimote_EXTENSION_MOTION_PLUS 0x0020
 #define dolphiimote_EXTENSION_BALANCE_BOARD 0x0030
+#define dolphiimote_EXTENSION_UNKNOWN 0x0050
 
 /*
   dolphiimote_CAPABILITIES_* are the capabilities that can be enabled.

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -314,8 +314,9 @@ dolphiimote_GUITAR_BUTTON_* are the Classic Controller buttons, as they are save
 #define dolphiimote_EXTENSION_GUITAR_HERO_GUITAR 0x0008
 #define dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS 0x0010
 #define dolphiimote_EXTENSION_MOTION_PLUS 0x0020
-#define dolphiimote_EXTENSION_BALANCE_BOARD 0x0030
-#define dolphiimote_EXTENSION_UNKNOWN 0x0050
+#define dolphiimote_EXTENSION_BALANCE_BOARD 0x0040
+//Ignore passthorugh since its not an exposed id.
+#define dolphiimote_EXTENSION_UNKNOWN 0x0100
 
 /*
   dolphiimote_CAPABILITIES_* are the capabilities that can be enabled.

--- a/DolphiiMote/Core/dolphiimote_host.cpp
+++ b/DolphiiMote/Core/dolphiimote_host.cpp
@@ -55,6 +55,10 @@ namespace dolphiimote {
     return wiimotes_flag;
   }
 
+  void dolphiimote_host::set_leds(int wiimote_number, int leds)
+  {
+	  discoverer.set_led_state(wiimote_number, leds);
+  }
   void dolphiimote_host::do_rumble(int wiimote_number, bool enable)
   {
     rumble.do_rumble(wiimote_number, enable);

--- a/DolphiiMote/Core/dolphiimote_host.cpp
+++ b/DolphiiMote/Core/dolphiimote_host.cpp
@@ -53,11 +53,14 @@ namespace dolphiimote {
     return wiimotes_flag;
   }
 
-  void dolphiimote_host::do_rumble(int wiimote_number)
+  void dolphiimote_host::do_rumble(int wiimote_number, bool enable)
   {
-    rumble.do_rumble(wiimote_number);
+    rumble.do_rumble(wiimote_number, enable);
   }
-
+  void dolphiimote_host::do_brief_rumble(int wiimote_number)
+  {
+	  rumble.do_brief_rumble(wiimote_number);
+  }
   void dolphiimote_host::data_received(int wiimote_number, const u16 channel, const void* const data, const u32 size)
   {
     auto u8_data = checked_array<const u8>((const u8*)data, size);

--- a/DolphiiMote/Core/dolphiimote_host.h
+++ b/DolphiiMote/Core/dolphiimote_host.h
@@ -35,6 +35,7 @@ namespace dolphiimote {
     dolphiimote_host(dolphiimote_callbacks callbacks);
 
 	void do_rumble(int wiimote_number, bool enable);
+	void set_leds(int wiimote_number, int leds);
     void do_brief_rumble(int wiimote_number);
 	void request_status(int wiimote_number);
     void enable_capabilities(int wiimote_number, wiimote_capabilities::type capability);

--- a/DolphiiMote/Core/dolphiimote_host.h
+++ b/DolphiiMote/Core/dolphiimote_host.h
@@ -35,9 +35,9 @@ namespace dolphiimote {
     dolphiimote_host(dolphiimote_callbacks callbacks);
 
 	void do_rumble(int wiimote_number, bool enable);
-    void do_brief_rumble(int wiimote_number);    
+    void do_brief_rumble(int wiimote_number);
+	void request_status(int wiimote_number);
     void enable_capabilities(int wiimote_number, wiimote_capabilities::type capability);
-    void determine_capabilities(int wiimote_number);
     void request_reporting_mode(int wiimote_number, u8 mode);
     virtual void data_received(int wiimote_number, const u16 channel, const void* const data, const u32 size);
     virtual void wiimote_connection_changed(int wiimote_number, bool connected);

--- a/DolphiiMote/Core/dolphiimote_host.h
+++ b/DolphiiMote/Core/dolphiimote_host.h
@@ -34,8 +34,8 @@ namespace dolphiimote {
   public:
     dolphiimote_host(dolphiimote_callbacks callbacks);
 
-    void do_rumble(int wiimote_number);    
-
+	void do_rumble(int wiimote_number, bool enable);
+    void do_brief_rumble(int wiimote_number);    
     void enable_capabilities(int wiimote_number, wiimote_capabilities::type capability);
     void determine_capabilities(int wiimote_number);
     void request_reporting_mode(int wiimote_number, u8 mode);

--- a/DolphiiMote/Core/logging_capability_discoverer.h
+++ b/DolphiiMote/Core/logging_capability_discoverer.h
@@ -28,6 +28,16 @@ namespace dolphiimote
     logging_capability_discoverer(std::map<int, wiimote> &wiimote_states, dolphiimote_callbacks callbacks, data_sender &sender, wiimote_reader &reader) : capability_discoverer(wiimote_states, callbacks, sender, reader)
     { }
 
+	inline virtual void init_and_identify_extension_controller(int wiimote)
+	{
+		log(Info, "Wiimote #%i: Attempting to identify and initialize extension controller", wiimote);
+		capability_discoverer::init_and_identify_extension_controller(wiimote);
+	}
+	inline virtual void send_status_request(int wiimote) {
+		log(Info, "Wiimote #%i: Sending status request", wiimote);
+		capability_discoverer::send_status_request(wiimote);
+	}
+
   private:
     inline virtual void handle_extension_connected(int wiimote)
     {
@@ -47,12 +57,6 @@ namespace dolphiimote
       capability_discoverer::enable_motion_plus_no_passthrough(wiimote);
     }
 
-    inline virtual void init_and_identify_extension_controller(int wiimote)
-    {
-      log(Info, "Wiimote #%i: Attempting to identify and initialize extension controller", wiimote);
-      capability_discoverer::init_and_identify_extension_controller(wiimote);
-    }
-
     inline virtual void enable_only_extension(int wiimote)
     {
       log(Info, "Wiimote #%i: Enabling only extension", wiimote);
@@ -62,10 +66,11 @@ namespace dolphiimote
     inline virtual void handle_motionplus_id_message(int wiimote, checked_array<const u8> data, dolphiimote_callbacks callbacks)
     {
       u8 error_bit = reader.read_error_bit(data);
-
-      if(error_bit == 0)
-        log(Info, "Wiimote #%i: MotionPlus available", wiimote);
-      else log(Info, "Wiimote #%i: MotionPlus not available", wiimote);
+	  if (is_set(wiimote_states[wiimote].available_capabilities, wiimote_capabilities::MotionPlus) != (error_bit == 0)) {
+		  if (error_bit == 0)
+			  log(Info, "Wiimote #%i: MotionPlus available", wiimote);
+		  else log(Info, "Wiimote #%i: MotionPlus not available", wiimote);
+	  }
 
       capability_discoverer::handle_motionplus_id_message(wiimote, data, callbacks);
     }

--- a/DolphiiMote/Core/rumbler.h
+++ b/DolphiiMote/Core/rumbler.h
@@ -29,7 +29,8 @@ namespace dolphiimote {
   {
   public:
     rumbler(std::map<int, wiimote> &current_wiimote_state, data_sender &sender);
-    void do_rumble(int wiimote_number);
+    void do_rumble(int wiimote_number, bool enable);
+	void do_brief_rumble(int wiimote_number);
 
   private:
     data_sender &sender;

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -17,6 +17,7 @@
 
 #include "serialization.h"
 #include "wiimote.h"
+#include "capability_discoverer.h"
 namespace dolphiimote { namespace serialization {
 	const float KG2LB = 2.20462262f;
     std::array<u8, 23> _start_rumble = { 0xA2, 0x15, 0x01 };
@@ -103,7 +104,7 @@ namespace dolphiimote { namespace serialization {
 			
 		}
 	}
-  void retrieve_motion_plus(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
+  void retrieve_motion_plus(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output, capability_discoverer &discoverer, int wiimote_number)
   {
     u8 speed_mask = ~0x03;
 	//If extension 5 has the first bit set, its invalid.
@@ -117,6 +118,7 @@ namespace dolphiimote { namespace serialization {
 
       output.motionplus.slow_modes = (extension_data[3] & 0x03) << 1 | (extension_data[4] & 0x02) >> 1;
       output.motionplus.extension_connected = extension_data[4] & 0x01;
+	  discoverer.handle_motion_plus_extension(wiimote_number, output.motionplus.extension_connected);
 	}
 
   }

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -106,9 +106,10 @@ namespace dolphiimote { namespace serialization {
   void retrieve_motion_plus(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
     u8 speed_mask = ~0x03;
-
-    if(extension_data.size() >= 6 && (extension_data[5] & 0x02))
+	//If extension 5 has the first bit set, its invalid.
+    if(extension_data.size() >= 6 && (extension_data[5] & 0x02) && !(extension_data[5] & 0x01))
     {
+		
       output.valid_data_flags |= dolphiimote_MOTIONPLUS_VALID;
 
       output.motionplus.yaw_down_speed = extension_data[0] + ((u16)(extension_data[3] & speed_mask) << 6);

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -172,6 +172,27 @@ namespace dolphiimote { namespace serialization {
     }
   }
 
+  void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
+  {
+	  if (extension_data.size() >= 6)
+	  {
+		  if ((extension_data[5] & 0x03) == 0)
+		  {
+			  output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
+
+			  output.classic_controller.left_stick_x = extension_data[0] & 0x3E;
+			  output.classic_controller.left_stick_y = extension_data[1] & 0x3E;
+
+			  output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
+			  output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
+
+			  output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
+			  output.classic_controller.right_trigger = extension_data[3] & 0x1F;
+
+			  output.classic_controller.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
+		  }
+	  }
+  }
   void retrieve_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
 	  if (extension_data.size() >= 6)
@@ -186,28 +207,23 @@ namespace dolphiimote { namespace serialization {
 		  output.guitar.buttons = ~((extension_data[4] << 8) | extension_data[5]);
 	  }
   }
-  void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
+
+  void retrieve_interleaved_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
-	  if(extension_data.size() >= 6)
-    {
-      if((extension_data[5] & 0x03) == 0)
-      {
-        output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
-
-        output.classic_controller.left_stick_x = extension_data[0] & 0x3E;
-        output.classic_controller.left_stick_y = extension_data[1] & 0x3E;
-
-        output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
-        output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
-
-        output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
-        output.classic_controller.right_trigger = extension_data[3] & 0x1F;
-
-        output.classic_controller.buttons = ~(((extension_data[4] & 0xFE ) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
-      }
-    }
+	  if (extension_data.size() >= 6)
+	  {
+		  if ((extension_data[5] & 0x03) == 0)
+		  {
+			  output.valid_data_flags |= dolphiimote_GUITAR_VALID;
+			  output.guitar.stick_x = extension_data[0] & 0x3E;
+			  output.guitar.stick_y = extension_data[1] & 0x3E;
+			  output.guitar.is_gh3 = (extension_data[0] & 0x80) == 0x80;
+			  output.guitar.tap_bar = extension_data[2] & 0x1F;
+			  output.guitar.whammy_bar = extension_data[3] & 0x1F;
+			  output.guitar.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
+		  }
+	  }
   }
-
   void retrieve_button_state(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output)
   {
     if(data.size() > 4)

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -109,7 +109,6 @@ namespace dolphiimote { namespace serialization {
 	//If extension 5 has the first bit set, its invalid.
     if(extension_data.size() >= 6 && (extension_data[5] & 0x02) && !(extension_data[5] & 0x01))
     {
-		
       output.valid_data_flags |= dolphiimote_MOTIONPLUS_VALID;
 
       output.motionplus.yaw_down_speed = extension_data[0] + ((u16)(extension_data[3] & speed_mask) << 6);
@@ -118,7 +117,11 @@ namespace dolphiimote { namespace serialization {
 
       output.motionplus.slow_modes = (extension_data[3] & 0x03) << 1 | (extension_data[4] & 0x02) >> 1;
       output.motionplus.extension_connected = extension_data[4] & 0x01;
-    }
+	}
+	else if (extension_data[5] & 0x02) {
+		//The data is invalid, so we cant trust knowing if the extension is connected or not.
+		output.motionplus.extension_connected = false;
+	}
   }
 
   void retrieve_nunchuck(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -118,10 +118,7 @@ namespace dolphiimote { namespace serialization {
       output.motionplus.slow_modes = (extension_data[3] & 0x03) << 1 | (extension_data[4] & 0x02) >> 1;
       output.motionplus.extension_connected = extension_data[4] & 0x01;
 	}
-	else if (extension_data[5] & 0x02) {
-		//The data is invalid, so we cant trust knowing if the extension is connected or not.
-		output.motionplus.extension_connected = false;
-	}
+
   }
 
   void retrieve_nunchuck(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)

--- a/DolphiiMote/Core/serialization.cpp
+++ b/DolphiiMote/Core/serialization.cpp
@@ -139,7 +139,7 @@ namespace dolphiimote { namespace serialization {
 
   void retrieve_interleaved_nunchuck(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
-    if(extension_data.size() >= 6 && !(extension_data[5] & 0x03))
+    if(extension_data.size() >= 6 && !(extension_data[5] & 0x02))
     {    
       output.valid_data_flags |= dolphiimote_NUNCHUCK_VALID;
 
@@ -174,23 +174,20 @@ namespace dolphiimote { namespace serialization {
 
   void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
-	  if (extension_data.size() >= 6)
+	  if (extension_data.size() >= 6 && !(extension_data[5] & 0x02))
 	  {
-		  if ((extension_data[5] & 0x03) == 0)
-		  {
-			  output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
+			output.valid_data_flags |= dolphiimote_CLASSIC_CONTROLLER_VALID;
 
-			  output.classic_controller.left_stick_x = extension_data[0] & 0x3E;
-			  output.classic_controller.left_stick_y = extension_data[1] & 0x3E;
+			output.classic_controller.left_stick_x = extension_data[0] & 0x3E;
+			output.classic_controller.left_stick_y = extension_data[1] & 0x3E;
 
-			  output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
-			  output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
+			output.classic_controller.right_stick_x = ((extension_data[0] & 0xC0) >> 3) | ((extension_data[1] & 0xC0) >> 5) | ((extension_data[2] & 0xC0) >> 7);
+			output.classic_controller.right_stick_y = extension_data[2] & 0x1F;
 
-			  output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
-			  output.classic_controller.right_trigger = extension_data[3] & 0x1F;
+			output.classic_controller.left_trigger = ((extension_data[2] & 0x60) >> 2) | ((extension_data[3] & 0xE0) >> 5);
+			output.classic_controller.right_trigger = extension_data[3] & 0x1F;
 
-			  output.classic_controller.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
-		  }
+			output.classic_controller.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
 	  }
   }
   void retrieve_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
@@ -210,18 +207,15 @@ namespace dolphiimote { namespace serialization {
 
   void retrieve_interleaved_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output)
   {
-	  if (extension_data.size() >= 6)
+	  if (extension_data.size() >= 6 && !(extension_data[5] & 0x02))
 	  {
-		  if ((extension_data[5] & 0x03) == 0)
-		  {
-			  output.valid_data_flags |= dolphiimote_GUITAR_VALID;
-			  output.guitar.stick_x = extension_data[0] & 0x3E;
-			  output.guitar.stick_y = extension_data[1] & 0x3E;
-			  output.guitar.is_gh3 = (extension_data[0] & 0x80) == 0x80;
-			  output.guitar.tap_bar = extension_data[2] & 0x1F;
-			  output.guitar.whammy_bar = extension_data[3] & 0x1F;
-			  output.guitar.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
-		  }
+			output.valid_data_flags |= dolphiimote_GUITAR_VALID;
+			output.guitar.stick_x = extension_data[0] & 0x3E;
+			output.guitar.stick_y = extension_data[1] & 0x3E;
+			output.guitar.is_gh3 = (extension_data[0] & 0x80) == 0x80;
+			output.guitar.tap_bar = extension_data[2] & 0x1F;
+			output.guitar.whammy_bar = extension_data[3] & 0x1F;
+			output.guitar.buttons = ~(((extension_data[4] & 0xFE) << 8) | (extension_data[5] & 0xFC) | ((extension_data[1] & 0x01) << 1) | (extension_data[0] & 0x01));
 	  }
   }
   void retrieve_button_state(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output)

--- a/DolphiiMote/Core/serialization.h
+++ b/DolphiiMote/Core/serialization.h
@@ -22,13 +22,14 @@
 #include "Util\collections.h"
 #include "../Dolphin/CommonTypes.h"
 #include "dolphiimote.h"
+#include "capability_discoverer.h"
 #include "wiimote.h"
 
 namespace dolphiimote { namespace serialization {
   const std::array<u8, 23>& start_rumble();
   const std::array<u8, 23>& stop_rumble();
   size_t rumble_size();
-  void retrieve_motion_plus(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
+  void retrieve_motion_plus(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output, capability_discoverer &discoverer, int wiimote_number);
   void retrieve_nunchuck(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   void retrieve_interleaved_nunchuck(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   void retrieve_button_state(u8 reporting_mode, checked_array<const u8> data, dolphiimote_wiimote_data &output);

--- a/DolphiiMote/Core/serialization.h
+++ b/DolphiiMote/Core/serialization.h
@@ -37,6 +37,7 @@ namespace dolphiimote { namespace serialization {
   void retrieve_classic_controller(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   void retrieve_interleaved_classic_controller(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   void retrieve_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
+  void retrieve_interleaved_guitar(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   void retrieve_balance_board(checked_array<const u8> extension_data, wiimote state, dolphiimote_wiimote_data &output);
   }
 }

--- a/DolphiiMote/Core/wiimote.cpp
+++ b/DolphiiMote/Core/wiimote.cpp
@@ -28,6 +28,7 @@ namespace dolphiimote
   const wiimote_extensions::type wiimote_extensions::MotionPlus = 0x20;
   const wiimote_extensions::type wiimote_extensions::BalanceBoard = 0x30;
   const wiimote_extensions::type wiimote_extensions::Passthrough = 0x40;
+  const wiimote_extensions::type wiimote_extensions::Unknown = 0x50;
 
   const wiimote_capabilities::type wiimote_capabilities::None = 0;
   const wiimote_capabilities::type wiimote_capabilities::MotionPlus = 0x2;

--- a/DolphiiMote/Core/wiimote.cpp
+++ b/DolphiiMote/Core/wiimote.cpp
@@ -27,6 +27,7 @@ namespace dolphiimote
   const wiimote_extensions::type wiimote_extensions::GHWorldTourDrums = 0x10;
   const wiimote_extensions::type wiimote_extensions::MotionPlus = 0x20;
   const wiimote_extensions::type wiimote_extensions::BalanceBoard = 0x30;
+  const wiimote_extensions::type wiimote_extensions::Passthrough = 0x40;
 
   const wiimote_capabilities::type wiimote_capabilities::None = 0;
   const wiimote_capabilities::type wiimote_capabilities::MotionPlus = 0x2;

--- a/DolphiiMote/Core/wiimote.cpp
+++ b/DolphiiMote/Core/wiimote.cpp
@@ -26,9 +26,9 @@ namespace dolphiimote
   const wiimote_extensions::type wiimote_extensions::GHGuitar = 0x08;
   const wiimote_extensions::type wiimote_extensions::GHWorldTourDrums = 0x10;
   const wiimote_extensions::type wiimote_extensions::MotionPlus = 0x20;
-  const wiimote_extensions::type wiimote_extensions::BalanceBoard = 0x30;
-  const wiimote_extensions::type wiimote_extensions::Passthrough = 0x40;
-  const wiimote_extensions::type wiimote_extensions::Unknown = 0x50;
+  const wiimote_extensions::type wiimote_extensions::BalanceBoard = 0x40;
+  const wiimote_extensions::type wiimote_extensions::Passthrough = 0x80;
+  const wiimote_extensions::type wiimote_extensions::Unknown = 0x100;
 
   const wiimote_capabilities::type wiimote_capabilities::None = 0;
   const wiimote_capabilities::type wiimote_capabilities::MotionPlus = 0x2;

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -137,6 +137,7 @@ namespace dolphiimote
     void set_extension_disabled()
     {
       enabled_capabilities &= ~wiimote_capabilities::Extension;
+	  available_capabilities &= ~wiimote_capabilities::Extension;
       extension_id = 0;
       extension_type = 0;
     }

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -140,6 +140,7 @@ namespace dolphiimote
 	  available_capabilities &= ~wiimote_capabilities::Extension;
       extension_id = 0;
       extension_type = 0;
+	  extension_motion_plus_state = false;
     }
 
     u64 extension_id;

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -140,7 +140,6 @@ namespace dolphiimote
 	  available_capabilities &= ~wiimote_capabilities::Extension;
       extension_id = 0;
       extension_type = 0;
-	  extension_motion_plus_state = false;
     }
 
     u64 extension_id;
@@ -151,8 +150,7 @@ namespace dolphiimote
     u8 led_state;
     bool rumble_state;  
 	wiimote_calibrations calibrations;
-	bool extension_motion_plus_state;
-	bool extension_motion_plus_valid;
+	std::chrono::steady_clock::time_point motion_plus_last_detected;
 	u8 battery_percentage;
   };
 

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -90,7 +90,7 @@ namespace dolphiimote
   { 
   public:
     typedef enumeration<uint32_t, 0> type;
-    static const type None, Nunchuck, ClassicController, ClassicControllerPro, GHGuitar, GHWorldTourDrums, MotionPlus, BalanceBoard;
+    static const type None, Nunchuck, ClassicController, ClassicControllerPro, GHGuitar, GHWorldTourDrums, MotionPlus, Passthrough, BalanceBoard;
   };
 
   class wiimote_data_handler

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -152,6 +152,7 @@ namespace dolphiimote
     bool rumble_state;  
 	wiimote_calibrations calibrations;
 	bool extension_motion_plus_state;
+	bool extension_motion_plus_valid;
   };
 
   class wiimote_message

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -153,6 +153,7 @@ namespace dolphiimote
 	wiimote_calibrations calibrations;
 	bool extension_motion_plus_state;
 	bool extension_motion_plus_valid;
+	u8 battery_percentage;
   };
 
   class wiimote_message

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -90,7 +90,7 @@ namespace dolphiimote
   { 
   public:
     typedef enumeration<uint32_t, 0> type;
-    static const type None, Nunchuck, ClassicController, ClassicControllerPro, GHGuitar, GHWorldTourDrums, MotionPlus, Passthrough, BalanceBoard;
+    static const type None, Unknown, Nunchuck, ClassicController, ClassicControllerPro, GHGuitar, GHWorldTourDrums, MotionPlus, Passthrough, BalanceBoard;
   };
 
   class wiimote_data_handler

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -150,6 +150,7 @@ namespace dolphiimote
     u8 led_state;
     bool rumble_state;  
 	wiimote_calibrations calibrations;
+	bool extension_motion_plus_state;
   };
 
   class wiimote_message

--- a/DolphiiMote/Core/wiimote_reader.cpp
+++ b/DolphiiMote/Core/wiimote_reader.cpp
@@ -71,7 +71,6 @@ namespace dolphiimote {
 
         if(!state.unfinished_request || !same_lowest_address(data[6], data[5], state.unfinished_request.val().address))
           return;
-		printf("Address: %x", state.unfinished_request.val().address);
         state.unfinished_request.val().callback(wiimote_number, data, callbacks);
         state.unfinished_request.invalidate();
       }

--- a/DolphiiMote/Core/wiimote_reader.cpp
+++ b/DolphiiMote/Core/wiimote_reader.cpp
@@ -71,7 +71,7 @@ namespace dolphiimote {
 
         if(!state.unfinished_request || !same_lowest_address(data[6], data[5], state.unfinished_request.val().address))
           return;
-
+		printf("Address: %x", state.unfinished_request.val().address);
         state.unfinished_request.val().callback(wiimote_number, data, callbacks);
         state.unfinished_request.invalidate();
       }

--- a/DolphiiMote/Dolphin/WiimoteReal.cpp
+++ b/DolphiiMote/Dolphin/WiimoteReal.cpp
@@ -645,7 +645,8 @@ bool IsValidBluetoothName(const std::string& name)
 {
 	return
 		"Nintendo RVL-CNT-01" == name ||
-		"Nintendo RVL-CNT-01-TR" == name;
+		"Nintendo RVL-CNT-01-TR" == name ||
+		"Nintendo RVL-WBC-01" == name;
 }
 
 }; // end of namespace

--- a/DolphiiMote/Dolphin/WiimoteReal.cpp
+++ b/DolphiiMote/Dolphin/WiimoteReal.cpp
@@ -176,7 +176,7 @@ void Wiimote::InterruptChannel(const u16 channel, const void* const _data, const
  	
  	// Disallow games from turning off all of the LEDs.
  	// It makes wiimote connection status confusing.
- 	if (rpt.first[1] == WM_LEDS)
+ 	/*if (rpt.first[1] == WM_LEDS)
 	{
 		auto& leds_rpt = *reinterpret_cast<wm_leds*>(&rpt.first[2]);
 		if (0 == leds_rpt.leds)
@@ -184,8 +184,8 @@ void Wiimote::InterruptChannel(const u16 channel, const void* const _data, const
 			// Turn on ALL of the LEDs.
 			leds_rpt.leds = 0xf;
 		}
-	}
-	else if (rpt.first[1] == WM_WRITE_SPEAKER_DATA)
+	}*/
+	if (rpt.first[1] == WM_WRITE_SPEAKER_DATA)
 	{
 		// Translate speaker data reports into rumble reports.
 		rpt.first[1] = WM_CMD_RUMBLE;

--- a/DolphiiMote/dolphiimote.def
+++ b/DolphiiMote/dolphiimote.def
@@ -3,9 +3,9 @@ EXPORTS
 	dolphiimote_init
 	dolphiimote_update
 	dolphiimote_set_reporting_mode
+	dolphiimote_request_status
 	dolphiimote_brief_rumble
 	dolphiimote_set_rumble
-	dolphiimote_determine_capabilities
 	dolphiimote_enable_capabilities
 	dolphiimote_log_level
 	dolphiimote_shutdown

--- a/DolphiiMote/dolphiimote.def
+++ b/DolphiiMote/dolphiimote.def
@@ -3,6 +3,7 @@ EXPORTS
 	dolphiimote_init
 	dolphiimote_update
 	dolphiimote_set_reporting_mode
+	dolphiimote_set_leds
 	dolphiimote_request_status
 	dolphiimote_brief_rumble
 	dolphiimote_set_rumble

--- a/DolphiiMote/dolphiimote.def
+++ b/DolphiiMote/dolphiimote.def
@@ -4,6 +4,7 @@ EXPORTS
 	dolphiimote_update
 	dolphiimote_set_reporting_mode
 	dolphiimote_brief_rumble
+	dolphiimote_set_rumble
 	dolphiimote_determine_capabilities
 	dolphiimote_enable_capabilities
 	dolphiimote_log_level

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -25,8 +25,9 @@ int bPause = 0;
 
 void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *data, void *userdata)
 {
-  if (bPause == 0)
-	printf("wiimote %i: ", wiimote_number);
+	if (bPause == 0) {
+		printf("wiimote %i: ", wiimote_number);
+	}
 
   if(data->button_state & dolphiimote_BUTTON_A)
   {
@@ -80,10 +81,14 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
 		  printf("Down ");
 		  dolphiimote_brief_rumble(wiimote_number);
 	  }
-	  if (data->button_state & dolphiimote_BUTTON_DPAD_RIGHT)
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_RIGHT) {
+		  dolphiimote_set_rumble(wiimote_number, 1);
 		  printf("Right ");
-	  if (data->button_state & dolphiimote_BUTTON_DPAD_LEFT)
+	  }
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_LEFT) {
+		  dolphiimote_set_rumble(wiimote_number, 0);
 		  printf("Left ");
+	  }
 	  if (data->button_state & dolphiimote_BUTTON_DPAD_UP)
 		  printf("Up ");
 	  if (data->button_state & dolphiimote_BUTTON_MINUS)
@@ -194,7 +199,6 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
 {
   printf("wiimote %i capabilities:\n", wiimote);
   printf("Extension: (0x%012llx) ", status->extension_id);
-
   switch(status->extension_type)
   {
     case dolphiimote_EXTENSION_NONE:
@@ -270,12 +274,6 @@ void init_dolphiimote(dolphiimote_callbacks callbacks)
   int wiimote_flags;
   int i;
   wiimote_flags = dolphiimote_init(callbacks);
-
-  for(i = 0; i < dolphiimote_MAX_WIIMOTES; i++, wiimote_flags >>= 1)
-  {
-    if(wiimote_flags & 0x01)
-      dolphiimote_determine_capabilities(i);
-  }
 }
 
 int main()

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -201,6 +201,9 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
 		state = 0 + 10 * wiimote;
       printf("None");
       break;
+	case dolphiimote_EXTENSION_UNKNOWN:
+		printf("Unknown");
+		break;
     case dolphiimote_EXTENSION_NUNCHUCK:
       printf("Nunchuck");
       break;

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -252,7 +252,6 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
 
   printf("\n");
 
-  Sleep(500);
   dolphiimote_set_reporting_mode(wiimote, 0x35);
 }
 

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -102,7 +102,7 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
 		  printf("Acc: %02d %02d %02d\t", data->acceleration.x, data->acceleration.y, data->acceleration.z);
 
 	  if (data->valid_data_flags & dolphiimote_MOTIONPLUS_VALID)
-		  printf("Motion Plus: %04X%04X%04X\t", data->motionplus.yaw_down_speed, data->motionplus.pitch_left_speed, data->motionplus.roll_left_speed);
+		  printf("Motion Plus: %04X %04X %04X, Extension connected: %d\t", data->motionplus.yaw_down_speed, data->motionplus.pitch_left_speed, data->motionplus.roll_left_speed, data->motionplus.extension_connected);
 
 	  if (data->valid_data_flags & dolphiimote_NUNCHUCK_VALID)
 	  {
@@ -113,8 +113,10 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
 
     if (data->valid_data_flags & dolphiimote_GUITAR_VALID)
     {
-  	  printf("Guitar: %02d %02d %02d %02d\t", data->guitar.stick_x, data->guitar.stick_y, data->guitar.is_gh3, data->guitar.buttons);
-  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_Green)
+  	  printf("Guitar: %02d %02d %02d\t", data->guitar.stick_x, data->guitar.stick_y, data->guitar.whammy_bar);
+	  if (data->guitar.is_gh3)
+		  printf("Guitar hero three controller\t");
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_GREEN)
   		  printf("Green\t");
   	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_RED)
   		  printf("Red\t");
@@ -124,6 +126,15 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
   		  printf("Blue\t");
   	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_ORANGE)
   		  printf("Orange\t");
+
+	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_PLUS)
+		  printf("+\t");
+	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_MINUS)
+		  printf("-\t");
+	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_STRUM_UP)
+		  printf("Strum Down\t");
+	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_STRUM_DOWN)
+		  printf("Strum Up\t");
     }
 
 	  if (data->valid_data_flags & dolphiimote_CLASSIC_CONTROLLER_VALID)
@@ -187,6 +198,7 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
   switch(status->extension_type)
   {
     case dolphiimote_EXTENSION_NONE:
+		state = 0 + 10 * wiimote;
       printf("None");
       break;
     case dolphiimote_EXTENSION_NUNCHUCK:

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -20,138 +20,169 @@
 #include <Windows.h>
 
 int state = 0;
+int bKeepRunning = 1;
+int bPause = 0;
 
 void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *data, void *userdata)
 {
-  printf("wiimote %i: ", wiimote_number);
+  if (bPause == 0)
+	printf("wiimote %i: ", wiimote_number);
 
   if(data->button_state & dolphiimote_BUTTON_A)
   {
     printf("A ");
 
-    if(state == 0)
+    if(state != 1 + 10 * wiimote_number)
     {
-      state = 1;
+      state = 1 + 10 * wiimote_number;
       dolphiimote_enable_capabilities(wiimote_number, dolphiimote_CAPABILITIES_MOTION_PLUS);
     }
-
-    dolphiimote_brief_rumble(wiimote_number);
   }
 
   if(data->button_state & dolphiimote_BUTTON_B)
   {
     printf("B ");
-    if(state == 1)
+    if(state != 0 + 10 * wiimote_number)
     {
-      state = 0;
+      state = 0 + 10 * wiimote_number;
       dolphiimote_enable_capabilities(wiimote_number, dolphiimote_CAPABILITIES_EXTENSION);
     }
   }
 
-  if(data -> button_state & dolphiimote_BUTTON_DPAD_DOWN)
-    printf("Down ");
-  if(data -> button_state & dolphiimote_BUTTON_DPAD_RIGHT)
-    printf("Right ");
-  if(data -> button_state & dolphiimote_BUTTON_DPAD_LEFT)
-    printf("Left ");
-  if(data -> button_state & dolphiimote_BUTTON_DPAD_UP)
-    printf("Up ");
-  if(data -> button_state & dolphiimote_BUTTON_MINUS)
-    printf("Minus ");
-  if(data -> button_state & dolphiimote_BUTTON_PLUS)
-    printf("Plus ");
-  if(data -> button_state & dolphiimote_BUTTON_HOME)
-    printf("Home ");
-  if(data -> button_state & dolphiimote_BUTTON_ONE)
-    printf("One ");
-  if(data -> button_state & dolphiimote_BUTTON_TWO)
-    printf("Two ");
-  if (data->valid_data_flags & dolphiimote_BALANCE_BOARD_VALID) {
-	  printf("Balance Board: Total: %02f, COGX: %02f, COGY: %02f", data->balance_board.weight_kg, data->balance_board.center_of_gravity_x, data->balance_board.center_of_gravity_y);
-  }
-  if(data->valid_data_flags & dolphiimote_ACCELERATION_VALID)
-    printf("Acc: %02d %02d %02d\t", data->acceleration.x, data->acceleration.y, data->acceleration.z);
-  
-  if(data->valid_data_flags & dolphiimote_MOTIONPLUS_VALID)
-    printf("Motion Plus: %04X%04X%04X\t", data->motionplus.yaw_down_speed, data->motionplus.pitch_left_speed, data->motionplus.roll_left_speed);
-
-  if(data->valid_data_flags & dolphiimote_NUNCHUCK_VALID)
+  if (data->button_state & dolphiimote_BUTTON_HOME)
   {
-    int c = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_C;
-    int z = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_Z;
-    printf("Nunchuck: C: %i, Z: %i, Acc: %02X%02X%02X Stick X: %i, Y: %i\t", c, z, data->nunchuck.x, data->nunchuck.y, data->nunchuck.z, data->nunchuck.stick_x, data->nunchuck.stick_y);
+	  printf("Home ");
+	  if (state != 2 + 10 * wiimote_number)
+	  {
+		  state = 2 + 10 * wiimote_number;
+		  dolphiimote_enable_capabilities(wiimote_number, dolphiimote_CAPABILITIES_EXTENSION | dolphiimote_CAPABILITIES_MOTION_PLUS);
+	  }
   }
-  if (data->valid_data_flags & dolphiimote_GUITAR_VALID)
+
+  if ((data->button_state & dolphiimote_BUTTON_MINUS) && (data->button_state & dolphiimote_BUTTON_PLUS))
   {
-
-	  printf("Guitar: %02d %02d %02d %02d\t", data->guitar.stick_x, data->guitar.stick_y, data->guitar.is_gh3, data->guitar.buttons);
-	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_Green)
-		  printf("Green\t");
-	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_RED)
-		  printf("Red\t");
-	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_YELLOW)
-		  printf("Yellow\t");
-	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_BLUE)
-		  printf("Blue\t");
-	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_ORANGE)
-		  printf("Orange\t");
+	  bKeepRunning = 0;
   }
-  if(data->valid_data_flags & dolphiimote_CLASSIC_CONTROLLER_VALID)
+
+  if ((data->button_state & dolphiimote_BUTTON_ONE) && (data->button_state & dolphiimote_BUTTON_TWO))
   {
-
-    int lx = data->classic_controller.left_stick_x;
-    int ly = data->classic_controller.left_stick_y;
-    int rx = data->classic_controller.right_stick_x;
-    int ry = data->classic_controller.right_stick_y;
-    int lt = data->classic_controller.left_trigger;
-    int rt = data->classic_controller.right_trigger;
-
-    printf("Classic: L:%02d,%02d R:%02d,%02d T:%02d,%02d\t",lx,ly,rx,ry,lt,rt);
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_A)
-      printf("A");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_B)
-      printf("B");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_X)
-      printf("X");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Y)
-      printf("Y");
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_LEFT)
-      printf("DL");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_RIGHT)
-      printf("DR");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_DOWN)
-      printf("DD");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_UP)
-      printf("DU");
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_LEFT)
-      printf("LT");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_RIGHT)
-      printf("RT");
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_LEFT)
-      printf("LZ");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_RIGHT)
-      printf("RZ");
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_PLUS)
-      printf("+");
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_MINUS)
-      printf("-");
-
-    if(data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_HOME)
-      printf("H");
+	  if (bPause == 1)
+		  bPause = 0;
+	  else
+		  bPause = 1;
+	  Sleep(500);
   }
 
-  printf("\n");
+  if (bPause == 0)
+  {
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_DOWN)
+	  {
+		  printf("Down ");
+		  dolphiimote_brief_rumble(wiimote_number);
+	  }
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_RIGHT)
+		  printf("Right ");
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_LEFT)
+		  printf("Left ");
+	  if (data->button_state & dolphiimote_BUTTON_DPAD_UP)
+		  printf("Up ");
+	  if (data->button_state & dolphiimote_BUTTON_MINUS)
+		  printf("Minus ");
+	  if (data->button_state & dolphiimote_BUTTON_PLUS)
+		  printf("Plus ");
+	  if (data->button_state & dolphiimote_BUTTON_ONE)
+		  printf("One ");
+	  if (data->button_state & dolphiimote_BUTTON_TWO)
+		  printf("Two ");
+
+    if (data->valid_data_flags & dolphiimote_BALANCE_BOARD_VALID)
+  	  printf("Balance Board: Total: %02f, COGX: %02f, COGY: %02f", data->balance_board.weight_kg, data->balance_board.center_of_gravity_x, data->balance_board.center_of_gravity_y);
+
+	  if (data->valid_data_flags & dolphiimote_ACCELERATION_VALID)
+		  printf("Acc: %02d %02d %02d\t", data->acceleration.x, data->acceleration.y, data->acceleration.z);
+
+	  if (data->valid_data_flags & dolphiimote_MOTIONPLUS_VALID)
+		  printf("Motion Plus: %04X%04X%04X\t", data->motionplus.yaw_down_speed, data->motionplus.pitch_left_speed, data->motionplus.roll_left_speed);
+
+	  if (data->valid_data_flags & dolphiimote_NUNCHUCK_VALID)
+	  {
+		  int c = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_C;
+		  int z = data->nunchuck.buttons & dolphiimote_NUNCHUCK_BUTTON_Z;
+		  printf("Nunchuck: C: %i, Z: %i, Acc: %02X%02X%02X Stick X: %i, Y: %i\t", c, z, data->nunchuck.x, data->nunchuck.y, data->nunchuck.z, data->nunchuck.stick_x, data->nunchuck.stick_y);
+	  }
+
+    if (data->valid_data_flags & dolphiimote_GUITAR_VALID)
+    {
+  	  printf("Guitar: %02d %02d %02d %02d\t", data->guitar.stick_x, data->guitar.stick_y, data->guitar.is_gh3, data->guitar.buttons);
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_Green)
+  		  printf("Green\t");
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_RED)
+  		  printf("Red\t");
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_YELLOW)
+  		  printf("Yellow\t");
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_BLUE)
+  		  printf("Blue\t");
+  	  if (data->guitar.buttons & dolphiimote_GUITAR_BUTTON_ORANGE)
+  		  printf("Orange\t");
+    }
+
+	  if (data->valid_data_flags & dolphiimote_CLASSIC_CONTROLLER_VALID)
+	  {
+
+		  int lx = data->classic_controller.left_stick_x;
+		  int ly = data->classic_controller.left_stick_y;
+		  int rx = data->classic_controller.right_stick_x;
+		  int ry = data->classic_controller.right_stick_y;
+		  int lt = data->classic_controller.left_trigger;
+		  int rt = data->classic_controller.right_trigger;
+
+		  printf("Classic: L:%02d,%02d R:%02d,%02d T:%02d,%02d\t", lx, ly, rx, ry, lt, rt);
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_A)
+			  printf("A");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_B)
+			  printf("B");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_X)
+			  printf("X");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Y)
+			  printf("Y");
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_LEFT)
+			  printf("DL");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_RIGHT)
+			  printf("DR");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_DOWN)
+			  printf("DD");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_DPAD_UP)
+			  printf("DU");
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_LEFT)
+			  printf("LT");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_TRIGGER_RIGHT)
+			  printf("RT");
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_LEFT)
+			  printf("LZ");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_Z_RIGHT)
+			  printf("RZ");
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_PLUS)
+			  printf("+");
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_MINUS)
+			  printf("-");
+
+		  if (data->classic_controller.buttons & dolphiimote_CLASSIC_CONTROLLER_BUTTON_HOME)
+			  printf("H");
+	  }
+
+	  printf("\n");
+  }
 }
 
 void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *status, void *userdata)
 {
   printf("wiimote %i capabilities:\n", wiimote);
-  printf("Extension: ");
+  printf("Extension: (0x%012llx) ", status->extension_id);
 
   switch(status->extension_type)
   {
@@ -172,6 +203,9 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
       break;
     case dolphiimote_EXTENSION_GUITAR_HERO_WORLD_TOUR_DRUMS:
       printf("Drums");
+      break;
+    case dolphiimote_EXTENSION_MOTION_PLUS:
+      printf("MotionPlus");
       break;
   }
 
@@ -200,11 +234,16 @@ void on_capabilities_changed(uint8_t wiimote, dolphiimote_capability_status *sta
 
   if(status->enabled_capabilities & dolphiimote_CAPABILITIES_IR)
     printf(" IR");
-  
+
   printf("\n");
 
   Sleep(500);
-  dolphiimote_set_reporting_mode(wiimote, 0x35);  
+  dolphiimote_set_reporting_mode(wiimote, 0x35);
+}
+
+void on_connection_changed(uint8_t wiimote_number, int connected)
+{
+	bKeepRunning = 0;
 }
 
 void on_log_received(const char* str, uint32_t size)
@@ -216,7 +255,7 @@ void init_dolphiimote(dolphiimote_callbacks callbacks)
 {
   int wiimote_flags;
   int i;
-  wiimote_flags = dolphiimote_init(callbacks);  
+  wiimote_flags = dolphiimote_init(callbacks);
 
   for(i = 0; i < dolphiimote_MAX_WIIMOTES; i++, wiimote_flags >>= 1)
   {
@@ -227,21 +266,22 @@ void init_dolphiimote(dolphiimote_callbacks callbacks)
 
 int main()
 {
-  dolphiimote_callbacks callbacks = { 0 };  
+  dolphiimote_callbacks callbacks = { 0 };
   int loop = 0;
 
   callbacks.data_received = on_data_received;
   callbacks.capabilities_changed = on_capabilities_changed;
+  callbacks.connection_changed = on_connection_changed;
   callbacks.log_received = on_log_received;
 
   dolphiimote_log_level(dolphiimote_LOG_LEVEL_DEBUG);
 
   init_dolphiimote(callbacks);
 
-  while(1)
+  while(bKeepRunning)
   {
     dolphiimote_update();
     Sleep(10);
   }
-  //dolphiimote_shutdown();
+  dolphiimote_shutdown();
 }


### PR DESCRIPTION
@zelmon64 I have modified your simulataneous_extensions branch and fixed it up a little. Now classic controllers and guitars are correctly detected, and when you disconnect a controller, it drops extension mode and goes back to direct mode. I have also implemented interleaved_guitar and fixed id detection so that the controller is always detected, even when switching between modes.