### PR TITLE
Add support for the speaker

### DIFF
--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -411,21 +411,20 @@ namespace dolphiimote {
 		int timer = samples_per_millisecond * BYTES_PER_REPORT;
 		sample_rate = 12000000 / sample_rate;
 		
-		sender.send(wiimote_message(wiimote_number, {0xa2, 0x14, 0x04}, 3, true));
-		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x04 }, 3, true));
-		sender.write_register(wiimote_number, 0xa20009, 0x01, 1);
-		sender.write_register(wiimote_number, 0xa20001, 0x08, 1);
-		sender.write_register(wiimote_number, 0xa20001, 0x00, 1);
-		sender.write_register(wiimote_number, 0xa20002, 0x40, 1);
-		sender.write_register(wiimote_number, 0xa20003, (sample_rate & 0x20), 1);
-		sender.write_register(wiimote_number, 0xa20004, (sample_rate & 0x10), 1);
-		sender.write_register(wiimote_number, 0xa20005, volume, 1);
-		sender.write_register(wiimote_number, 0xa20006, 0x00, 1);
-		sender.write_register(wiimote_number, 0xa20007, 0x00, 1);
-		sender.write_register(wiimote_number, 0xa20008, 0x01, 1);
-
-		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x00 }, 3, true));
-		std::this_thread::sleep_for(std::chrono::milliseconds(500));
+		sender.send_now(wiimote_message(wiimote_number, {0xa2, 0x14, 0x04}, 3, true));
+		sender.send_now(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x04 }, 3, true));
+		sender.write_register_now(wiimote_number, 0xa20009, 0x01, 1);
+		sender.write_register_now(wiimote_number, 0xa20001, 0x08, 1);
+		sender.write_register_now(wiimote_number, 0xa20001, 0x00, 1);
+		sender.write_register_now(wiimote_number, 0xa20002, 0x40, 1);
+		sender.write_register_now(wiimote_number, 0xa20003, (sample_rate & 0x20), 1);
+		sender.write_register_now(wiimote_number, 0xa20004, (sample_rate & 0x10), 1);
+		sender.write_register_now(wiimote_number, 0xa20005, volume, 1);
+		sender.write_register_now(wiimote_number, 0xa20006, 0x00, 1);
+		sender.write_register_now(wiimote_number, 0xa20007, 0x00, 1);
+		sender.write_register_now(wiimote_number, 0xa20008, 0x01, 1);
+		
+		sender.send_now(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x00 }, 3, true));
 		std::thread(std::bind(&capability_discoverer::sound_thread, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),wiimote_number, full_file, timer).detach();
 
 		log(Info, "Wiimote #%i: Playing sound, sample rate: %i", wiimote_number, sample_rate);

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -425,7 +425,7 @@ namespace dolphiimote {
 		sender.write_register(wiimote_number, 0xa20008, 0x01, 1);
 
 		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x00 }, 3, true));
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		std::this_thread::sleep_for(std::chrono::milliseconds(500));
 		std::thread(std::bind(&capability_discoverer::sound_thread, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),wiimote_number, full_file, timer).detach();
 
 		log(Info, "Wiimote #%i: Playing sound, sample rate: %i", wiimote_number, sample_rate);

--- a/DolphiiMote/Core/capability_discoverer.cpp
+++ b/DolphiiMote/Core/capability_discoverer.cpp
@@ -16,9 +16,14 @@
 // along with DolphiiMote.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "capability_discoverer.h"
-#include <chrono>
+#include <list>
+#include <iterator>
 #include <thread>
-
+#include "../Dolphin/WiimoteReal.h"
+#define NTOHL(n) (((((unsigned long)(n) & 0xFF)) << 24) | \
+                  ((((unsigned long)(n) & 0xFF00)) << 8) | \
+                  ((((unsigned long)(n) & 0xFF0000)) >> 8) | \
+                  ((((unsigned long)(n) & 0xFF000000)) >> 24))
 namespace dolphiimote {
 	const int MAX_BATTERY_VALUE = 0xc8;
 	void capability_discoverer::data_received(dolphiimote_callbacks &callbacks, int wiimote_number, checked_array<const u8> data)
@@ -101,7 +106,6 @@ namespace dolphiimote {
 	void capability_discoverer::handle_extension_controller_changed(bool extension_controller_connected, int wiimote, bool& changed)
 	{
 		auto& mote = wiimote_states[wiimote];
-		printf("State changed to: %d", extension_controller_connected);
 		if (extension_controller_connected && !is_set(mote.available_capabilities, wiimote_capabilities::Extension))
 		{
 			handle_extension_connected(wiimote);
@@ -348,10 +352,88 @@ namespace dolphiimote {
 		//According to wiibrew: init by writing 0x55 to 0x(4)A400F0, then writing 0x00 to 0x(4)A400FB
 	}
 
+	void capability_discoverer::sound_thread(int wiimote_number, std::list<std::array<u8, 23>> full_file, int pause) {
+		auto& mote = wiimote_states[wiimote_number];
+		mote.sound_playing = true;
+		for (std::array<u8, 23> frame : full_file) {
+			if (!mote.sound_playing) break;
+			std::this_thread::sleep_for(std::chrono::milliseconds(pause));
+			sender.send_now(wiimote_message(wiimote_number, frame, 23, true));
+		}
+	}
+	void capability_discoverer::stop_sound(int wiimote_number)
+	{
+		wiimote_states[wiimote_number].sound_playing = false;
+		//Mute speaker
+		sender.send_now(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x04 }, 3, true));
+		//Disable speaker
+		sender.send_now(wiimote_message(wiimote_number, { 0xa2, 0x14, 0x00 }, 3, true));
+	}
+	void capability_discoverer::play_sound_pcm(int wiimote_number, char* file, u8 volume)
+	{
+		auto& mote = wiimote_states[wiimote_number];
+		mote.sound_playing = false;
+		std::ifstream speaker_file(file, std::ios::binary | std::ios::in);
+		std::list <std::array<u8, 23>> full_file;
+		uint32_t temp;
+		speaker_file.read(reinterpret_cast<char *>(&temp), sizeof(temp));
+		//big_endian to little_endian
+		temp = NTOHL(temp);
+		if (temp != PCM_MAGIC) {
+			log(Info, "Wiimote #%i: Unable to play sound, invalid header magic constant", wiimote_number);
+			return;
+		}
+		speaker_file.seekg(4 * 3);
+		speaker_file.read(reinterpret_cast<char *>(&temp), sizeof(temp));
+		temp = NTOHL(temp);
+		if (temp != PCM_ENCODING) {
+			log(Info, "Wiimote #%i: Unable to play sound, invalid encoding", wiimote_number);
+			return;
+		}
+		speaker_file.read(reinterpret_cast<char *>(&temp), sizeof(temp));
+		temp = NTOHL(temp);
+		int sample_rate = temp;
+		log(Info, "Wiimote #%i: Playing sound, sample rate: %i", wiimote_number, sample_rate);
+		speaker_file.seekg(0);
+		char* speaker_data = new char[20];
+		u8 read_bytes = 0;
+		do {
+			speaker_file.read(speaker_data, 20);
+			read_bytes = speaker_file.gcount();
+			std::array<u8, 23> data_to_send = { 0xa2,0x18,read_bytes << 3 };
+			for (int i = 0; i < 20; i++) {
+				data_to_send[i + 3] = speaker_data[i];
+			}
+			full_file.push_back(data_to_send);
+		} while (read_bytes > 0);
+		speaker_file.close();
+		float samples_per_millisecond = ((1 / sample_rate) * 1000);
+		int timer = samples_per_millisecond * BYTES_PER_REPORT;
+		sample_rate = 12000000 / sample_rate;
+		
+		sender.send(wiimote_message(wiimote_number, {0xa2, 0x14, 0x04}, 3, true));
+		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x04 }, 3, true));
+		sender.write_register(wiimote_number, 0xa20009, 0x01, 1);
+		sender.write_register(wiimote_number, 0xa20001, 0x08, 1);
+		sender.write_register(wiimote_number, 0xa20001, 0x00, 1);
+		sender.write_register(wiimote_number, 0xa20002, 0x40, 1);
+		sender.write_register(wiimote_number, 0xa20003, (sample_rate & 0x20), 1);
+		sender.write_register(wiimote_number, 0xa20004, (sample_rate & 0x10), 1);
+		sender.write_register(wiimote_number, 0xa20005, volume, 1);
+		sender.write_register(wiimote_number, 0xa20006, 0x00, 1);
+		sender.write_register(wiimote_number, 0xa20007, 0x00, 1);
+		sender.write_register(wiimote_number, 0xa20008, 0x01, 1);
+
+		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x19, 0x00 }, 3, true));
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		std::thread(std::bind(&capability_discoverer::sound_thread, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),wiimote_number, full_file, timer).detach();
+
+		log(Info, "Wiimote #%i: Playing sound, sample rate: %i", wiimote_number, sample_rate);
+	}
 
 	void capability_discoverer::send_status_request(int wiimote_number)
 	{
-		sender.send(wiimote_message(wiimote_number, {0xa2, 0x15, 0}, 3, true));
+		sender.send(wiimote_message(wiimote_number, { 0xa2, 0x15, 0 }, 3, true));
 	}
 
 	void capability_discoverer::enable_motion_plus_no_passthrough(int wiimote_number)
@@ -380,7 +462,7 @@ namespace dolphiimote {
 
 	void capability_discoverer::enable_motion_plus_extension_passthrough(int wiimote_number)
 	{
-		wiimote mote = wiimote_states[wiimote_number];
+		auto& mote = wiimote_states[wiimote_number];
 		//If we have no idea what is currently plugged into the motion plus, swap to direct to get an id, then swap back to passthrough.
 		if (mote.extension_id == 0) {
 			printf("Could not detect id, refreshing...");

--- a/DolphiiMote/Core/capability_discoverer.h
+++ b/DolphiiMote/Core/capability_discoverer.h
@@ -19,9 +19,15 @@
 #define DOLPHIIMOTE_CAPABILITY_DISCOVERER_H
 
 #include <map>
+#include <chrono>
+#include <list>
 #include "wiimote.h"
 #include "data_sender.h"
 #include "wiimote_reader.h"
+#include <thread>
+#include <iostream>
+#include <fstream>
+#include <Windows.h>
 
 namespace dolphiimote
 {
@@ -36,6 +42,8 @@ namespace dolphiimote
 
     virtual void init_and_identify_extension_controller(int wiimote_number);
     virtual void send_status_request(int wiimote_number);
+	virtual void play_sound_pcm(int wiimote_number, char* file, u8 volume);
+	virtual void stop_sound(int wiimote_number);
 	virtual void set_led_state(int wiimote_number, int led_state);
     virtual void enable(int wiimote_number, wiimote_capabilities::type capabilities_to_enable);
 	virtual void handle_motion_plus_extension(int wiimote_number, bool extension_connected);
@@ -60,13 +68,17 @@ namespace dolphiimote
     virtual void enable_only_extension(int wiimote);
     virtual void handle_extension_connected(int wiimote);
     virtual void handle_extension_disconnected(int wiimote);
+	virtual void sound_thread(int wiimote_number, std::list <std::array<u8, 23>> full_file, int pause);
 
     u64 capability_discoverer::read_extension_id(checked_array<const u8> data);
-
     std::map<int, wiimote> &wiimote_states;
     dolphiimote_callbacks callbacks;
     data_sender &sender;
     wiimote_reader &reader;
+	const int BYTES_PER_REPORT = 20;
+	const int PCM_MAGIC = 0x2e736e64;
+	const int PCM_ENCODING = 0x02;
   };
 }
+
 #endif

--- a/DolphiiMote/Core/data_sender.cpp
+++ b/DolphiiMote/Core/data_sender.cpp
@@ -63,6 +63,17 @@ namespace dolphiimote {
     {
       messages.push(message);
     }
+	void data_sender::write_register_now(int wiimote_number, u32 address, uint64_t bytes, u8 size)
+	{
+		std::array<u8, 23> data = { 0xA2, 0x16, 0x04, address >> 16, address >> 8, address , size };
+
+		std::memset(data.data() + 7, 0, 16);
+
+		for (int i = 0; i < size; i++)
+			data[7 + size - 1 - i] = (u8)(bytes >> (i * 8));
+
+		send_now(wiimote_message(wiimote_number, data, 23));
+	}
 	void data_sender::send_now(wiimote_message &message)
 	{
 		if (message.preserve_rumble())

--- a/DolphiiMote/Core/data_sender.cpp
+++ b/DolphiiMote/Core/data_sender.cpp
@@ -63,7 +63,16 @@ namespace dolphiimote {
     {
       messages.push(message);
     }
+	void data_sender::send_now(wiimote_message &message)
+	{
+		if (message.preserve_rumble())
+		{
+			message.message()[2] &= ~(0x1);
+			message.message()[2] |= (u8)state[message.wiimote()].rumble_active();
+		}
 
+		WiimoteReal::WriteImmediately(message.wiimote(), 65, &message.message()[0], message.size());
+	}
     void data_sender::send_message(wiimote_message &message)
     {
       if(message.preserve_rumble())

--- a/DolphiiMote/Core/data_sender.h
+++ b/DolphiiMote/Core/data_sender.h
@@ -34,6 +34,7 @@ namespace dolphiimote {
     void write_register(int wiimote_number, u32 address, uint64_t bytes, u8 size);
 
     void send(const wiimote_message &message);
+	void send_now(wiimote_message &message);
 
   private:
     void send_message(wiimote_message &message);

--- a/DolphiiMote/Core/data_sender.h
+++ b/DolphiiMote/Core/data_sender.h
@@ -32,6 +32,7 @@ namespace dolphiimote {
     void write_register(int wiimote_number, u32 address, std::array<u8, 16> bytes, u8 size);
     void write_register(int wiimote_number, u32 address, uint64_t bytes, u8 size, std::function<void(int)> callback);
     void write_register(int wiimote_number, u32 address, uint64_t bytes, u8 size);
+	void write_register_now(int wiimote_number, u32 address, uint64_t bytes, u8 size);
 
     void send(const wiimote_message &message);
 	void send_now(wiimote_message &message);

--- a/DolphiiMote/Core/dolphiimote.cpp
+++ b/DolphiiMote/Core/dolphiimote.cpp
@@ -43,6 +43,20 @@ void dolphiimote_set_rumble(uint8_t  wiimote_number, uint8_t enable)
 
 	host->do_rumble(wiimote_number, enable);
 }
+void dolphiimote_play_sound_pcm(uint8_t  wiimote_number, char* file, uint8_t volume)
+{
+	if (!host)
+		return;
+
+	host->play_sound_pcm(wiimote_number, file, volume);
+}
+void dolphiimote_stop_sound(uint8_t  wiimote_number)
+{
+	if (!host)
+		return;
+
+	host->stop_sound(wiimote_number);
+}
 void dolphiimote_set_leds(uint8_t  wiimote_number, uint8_t leds)
 {
 	if (!host)
@@ -77,7 +91,7 @@ void dolphiimote_shutdown()
 {
 	if(!host)
 	  return;
-
+	host->stop_all_sounds();
 	host.reset();
   WiimoteReal::Shutdown();
 }
@@ -89,7 +103,8 @@ void dolphiimote_log_level(uint8_t level)
 
 void dolphiimote_update()
 {
-  if(!host)
+  //If sound is playing, there is not enough bandwith available to update, so updating will freeze threads, stopping us from stopping audio.
+  if(!host || host->sound_playing())
 	  return;
 
   for(int i = 0; i < 4; i++)

--- a/DolphiiMote/Core/dolphiimote.h
+++ b/DolphiiMote/Core/dolphiimote.h
@@ -214,7 +214,14 @@ void dolphiimote_update();
   Check http://wiibrew.org/wiki/Wiimote#Data_Reporting for more information
 */
 void dolphiimote_set_reporting_mode(uint8_t wiimote_number, uint8_t mode);
-
+/*
+  Play a sound file 
+*/
+void dolphiimote_play_sound_pcm(uint8_t  wiimote_number, char* file, uint8_t volume);
+/*
+  Stop all playing sounds
+*/
+void dolphiimote_stop_sound(uint8_t  wiimote_number);
 /*
   Rumble briefly - 200 ms
 */

--- a/DolphiiMote/Core/dolphiimote_host.cpp
+++ b/DolphiiMote/Core/dolphiimote_host.cpp
@@ -110,8 +110,8 @@ namespace dolphiimote {
   }
   void dolphiimote_host::stop_all_sounds()
   {
-	  for (std::pair<int, wiimote> mote : current_wiimote_state) {
-		  mote.second.sound_playing = false;
+	  for (int i = 0; i < number_of_wiimotes(); i++) {
+		  stop_sound(i);
 	  }
   }
   void dolphiimote_host::update()

--- a/DolphiiMote/Core/dolphiimote_host.cpp
+++ b/DolphiiMote/Core/dolphiimote_host.cpp
@@ -63,6 +63,12 @@ namespace dolphiimote {
   {
     rumble.do_rumble(wiimote_number, enable);
   }
+  void dolphiimote_host::stop_sound(int wiimote_number) {
+	  discoverer.stop_sound(wiimote_number);
+  }
+  void dolphiimote_host::play_sound_pcm(int wiimote_number, char* file, u8 volume) {
+	  discoverer.play_sound_pcm(wiimote_number, file, volume);
+  }
   void dolphiimote_host::do_brief_rumble(int wiimote_number)
   {
 	  rumble.do_brief_rumble(wiimote_number);
@@ -96,7 +102,18 @@ namespace dolphiimote {
 
   void dolphiimote_host::wiimote_connection_changed(int wiimote_number, bool connected)
   { }
-
+  bool dolphiimote_host::sound_playing() {
+	  for (std::pair<int, wiimote> mote : current_wiimote_state) {
+		  if (mote.second.sound_playing) return true;
+	  }
+	  return false;
+  }
+  void dolphiimote_host::stop_all_sounds()
+  {
+	  for (std::pair<int, wiimote> mote : current_wiimote_state) {
+		  mote.second.sound_playing = false;
+	  }
+  }
   void dolphiimote_host::update()
   {
     reader();

--- a/DolphiiMote/Core/dolphiimote_host.h
+++ b/DolphiiMote/Core/dolphiimote_host.h
@@ -36,10 +36,14 @@ namespace dolphiimote {
 
 	void do_rumble(int wiimote_number, bool enable);
 	void set_leds(int wiimote_number, int leds);
+	void play_sound_pcm(int wiimote_number, char* file, u8 volume);
+	void stop_sound(int wiimote_number);
+	void stop_all_sounds();
     void do_brief_rumble(int wiimote_number);
 	void request_status(int wiimote_number);
     void enable_capabilities(int wiimote_number, wiimote_capabilities::type capability);
     void request_reporting_mode(int wiimote_number, u8 mode);
+	bool sound_playing();
     virtual void data_received(int wiimote_number, const u16 channel, const void* const data, const u32 size);
     virtual void wiimote_connection_changed(int wiimote_number, bool connected);
     void update();

--- a/DolphiiMote/Core/logging_capability_discoverer.h
+++ b/DolphiiMote/Core/logging_capability_discoverer.h
@@ -37,7 +37,14 @@ namespace dolphiimote
 		log(Info, "Wiimote #%i: Sending status request", wiimote);
 		capability_discoverer::send_status_request(wiimote);
 	}
-
+	inline virtual void play_sound_pcm(int wiimote_number, char* file, u8 volume) {
+		log(Info, "Wiimote #%i: Playing PCM Sound %s at volume %i", wiimote_number, file, volume);
+		capability_discoverer::play_sound_pcm(wiimote_number, file, volume);
+	}
+	inline virtual void stop_sound(int wiimote_number) {
+		log(Info, "Wiimote #%i: Stopping all sounds", wiimote_number);
+		capability_discoverer::stop_sound(wiimote_number);
+	}
   private:
     inline virtual void handle_extension_connected(int wiimote)
     {

--- a/DolphiiMote/Core/wiimote.h
+++ b/DolphiiMote/Core/wiimote.h
@@ -22,6 +22,8 @@
 #include "dolphiimote.h"
 #include <chrono>
 #include <array>
+#include <iostream>
+#include <fstream>
 #include "Util/collections.h"
 #include "Util/enum.h"
 
@@ -152,6 +154,7 @@ namespace dolphiimote
 	wiimote_calibrations calibrations;
 	std::chrono::steady_clock::time_point motion_plus_last_detected;
 	u8 battery_percentage;
+	bool sound_playing = false;
   };
 
   class wiimote_message

--- a/DolphiiMote/Dolphin/IOWin.cpp
+++ b/DolphiiMote/Dolphin/IOWin.cpp
@@ -472,7 +472,10 @@ int Wiimote::IOWrite(const u8* buf, int len)
 			}
 			else
 			{
-				WARN_LOG(WIIMOTE, "IOWrite[MSBT_STACK_MS]: ERROR: %08x", err);
+				if (err != 0x00000015) {
+					//Printing errors is less useful if the error slows down communication
+					WARN_LOG(WIIMOTE, "IOWrite[MSBT_STACK_MS]: ERROR: %08x", err);
+				}
 			}
 		}
 

--- a/DolphiiMote/Dolphin/WiimoteReal.cpp
+++ b/DolphiiMote/Dolphin/WiimoteReal.cpp
@@ -185,14 +185,14 @@ void Wiimote::InterruptChannel(const u16 channel, const void* const _data, const
 			leds_rpt.leds = 0xf;
 		}
 	}*/
-	if (rpt.first[1] == WM_WRITE_SPEAKER_DATA)
+	/*if (rpt.first[1] == WM_WRITE_SPEAKER_DATA)
 	{
 		// Translate speaker data reports into rumble reports.
 		rpt.first[1] = WM_CMD_RUMBLE;
 		// Keep only the rumble bit.
 		rpt.first[2] &= 0x1;
 		rpt.second = 3;
-	}
+	}*/
 
 	m_write_reports.Push(rpt);
 }
@@ -220,7 +220,9 @@ bool Wiimote::Read()
 	delete[] rpt.first;
 	return false;
 }
-
+void Wiimote::WriteImmediately(const u16 channel, const u8* const data, const u32 size) {
+	IOWrite(data, size);
+}
 bool Wiimote::Write()
 {
 	if (!m_write_reports.Empty())
@@ -228,7 +230,6 @@ bool Wiimote::Write()
 		Report const& rpt = m_write_reports.Front();
 		
 		bool const is_speaker_data = rpt.first[1] == WM_WRITE_SPEAKER_DATA;
-		
 		if (!is_speaker_data || m_last_audio_report.GetTimeDifference() > 5)
 		{
 			IOWrite(rpt.first, rpt.second);
@@ -602,6 +603,13 @@ void Refresh()
 	Initialize();
 }
 
+void WriteImmediately(int _WiimoteNumber, u16 _channelID, const u8* _pData, u32 _Size)
+{
+	std::lock_guard<std::recursive_mutex> lk(g_refresh_lock);
+
+	if (g_wiimotes[_WiimoteNumber])
+		g_wiimotes[_WiimoteNumber]->WriteImmediately(_channelID, _pData, _Size);
+}
 void InterruptChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size)
 {
 	std::lock_guard<std::recursive_mutex> lk(g_refresh_lock);

--- a/DolphiiMote/Dolphin/WiimoteReal.h
+++ b/DolphiiMote/Dolphin/WiimoteReal.h
@@ -46,6 +46,7 @@ public:
 
 	void ControlChannel(const u16 channel, const void* const data, const u32 size);
 	void InterruptChannel(const u16 channel, const void* const data, const u32 size);
+	void WriteImmediately(const u16 channel, const u8* const data, const u32 size);
 	void Update();
 
 	Report ProcessReadQueue();
@@ -158,6 +159,7 @@ extern WiimoteScanner g_wiimote_scanner;
 extern Wiimote *g_wiimotes[4];
 
 void InterruptChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size);
+void WriteImmediately(int _WiimoteNumber, u16 _channelID, const u8* _pData, u32 _Size);
 void ControlChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size);
 void Update(int _WiimoteNumber);
 

--- a/DolphiiMote/dolphiimote.def
+++ b/DolphiiMote/dolphiimote.def
@@ -10,3 +10,5 @@ EXPORTS
 	dolphiimote_enable_capabilities
 	dolphiimote_log_level
 	dolphiimote_shutdown
+	dolphiimote_play_sound_pcm
+	dolphiimote_stop_sound

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -297,7 +297,7 @@ int main()
   dolphiimote_log_level(dolphiimote_LOG_LEVEL_DEBUG);
 
   init_dolphiimote(callbacks);
-
+  dolphiimote_update();
   while(bKeepRunning)
   {
     dolphiimote_update();

--- a/Dolphiimote.Test/Test/main.c
+++ b/Dolphiimote.Test/Test/main.c
@@ -72,8 +72,16 @@ void on_data_received(uint8_t wiimote_number, struct dolphiimote_wiimote_data *d
 	  else
 		  bPause = 1;
 	  Sleep(500);
+	  state = 2 + 10 * wiimote_number;
   }
 
+  if (data->button_state & dolphiimote_BUTTON_DPAD_RIGHT) {
+	  if (state != 5 + 10 * wiimote_number)
+	  {
+		  state = 5 + 10 * wiimote_number;
+		  dolphiimote_set_rumble(wiimote_number, 1);
+	  }
+  }
   if (bPause == 0)
   {
 	  if (data->button_state & dolphiimote_BUTTON_DPAD_DOWN)


### PR DESCRIPTION
Some changes had to be made to WiimoteReal as it was designed to disable speaker functionality.
The speaker functions create their own thread for playback, and when any speaker is playing sound, all normal reports are disabled, and sound is sent directly bypassing the report cache. This is because we want to use all bandwith to play samples, and without disabling, dolphiimote_update() would actually wait until it could send/receive and block the main thread.